### PR TITLE
Add unit tests in Elasticsearch Connector

### DIFF
--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -112,6 +112,12 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>junit</groupId>

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientFactory.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientFactory.java
@@ -113,7 +113,7 @@ public class AwsRestHighLevelClientFactory
         if (useAwsCredentials) {
             logger.debug("Creating Client using Aws Credentials.");
             return new AwsRestHighLevelClient.Builder(endpoint)
-                    .withCredentials(DefaultCredentialsProvider.create()).build();
+                    .withCredentials(DefaultCredentialsProvider.builder().build()).build();
         }
         else {
             Matcher credentials = credentialsPattern.matcher(endpoint);

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AWSRequestSigningApacheInterceptorTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AWSRequestSigningApacheInterceptorTest.java
@@ -47,8 +47,8 @@ import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -120,17 +120,10 @@ public class AWSRequestSigningApacheInterceptorTest
     {
         HttpRequest request = new BasicHttpRequest(HTTP_METHOD_GET, TEST_URI_INVALID);
 
-        try {
-            interceptor.process(request, context);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Invalid URI",
-                    ex.getMessage().contains(INVALID_URI_MESSAGE));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> interceptor.process(request, context));
+        assertTrue("Exception message should contain Invalid URI",
+                ex.getMessage().contains(INVALID_URI_MESSAGE));
     }
 
     @Test
@@ -198,16 +191,9 @@ public class AWSRequestSigningApacheInterceptorTest
         lenient().when(requestLine.getMethod()).thenReturn(HTTP_METHOD_GET);
         lenient().when(requestLine.getUri()).thenReturn("https://test.com/path?query=value%");
 
-        try {
-            interceptor.process(request, context);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Invalid URI",
-                    ex.getMessage().contains(INVALID_URI_MESSAGE));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> interceptor.process(request, context));
+        assertTrue("Exception message should contain Invalid URI",
+                ex.getMessage().contains(INVALID_URI_MESSAGE));
     }
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AWSRequestSigningApacheInterceptorTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AWSRequestSigningApacheInterceptorTest.java
@@ -1,0 +1,213 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.elasticsearch;
+
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.util.EntityUtils;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
+
+import java.util.Collections;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * This class is used to test the AWSRequestSigningApacheInterceptor class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AWSRequestSigningApacheInterceptorTest
+{
+    private static final String TEST_URI = "https://search-test.us-east-1.es.amazonaws.com/test";
+    private static final String TEST_URI_INVALID = "invalid://[malformed uri";
+    private static final String TEST_BODY = "test body";
+    private static final String HTTP_METHOD_GET = "GET";
+    private static final String INVALID_URI_MESSAGE = "Invalid URI";
+
+    @Mock
+    private AwsV4HttpSigner mockSigner;
+
+    @Mock
+    private AwsCredentialsProvider mockCredentialsProvider;
+
+    private AWSRequestSigningApacheInterceptor interceptor;
+    private HttpContext context;
+
+    @Before
+    public void setUp()
+    {
+        interceptor = new AWSRequestSigningApacheInterceptor("es", mockSigner, mockCredentialsProvider, "us-east-1");
+        context = new BasicHttpContext();
+        HttpHost host = HttpHost.create("https://search-test.us-east-1.es.amazonaws.com");
+        context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, host);
+        
+        // Mock the signer and credentials provider
+        AwsCredentials mockCredentials = new AwsCredentials() {
+            @Override
+            public String accessKeyId() {
+                return "test-access-key";
+            }
+            
+            @Override
+            public String secretAccessKey() {
+                return "test-secret-key";
+            }
+        };
+        lenient().when(mockCredentialsProvider.resolveCredentials()).thenReturn(mockCredentials);
+        
+        SignedRequest mockSignedRequest = mock(SignedRequest.class);
+        SdkHttpFullRequest mockRequest = mock(SdkHttpFullRequest.class);
+        lenient().when(mockSignedRequest.request()).thenReturn(mockRequest);
+        lenient().when(mockRequest.headers()).thenReturn(Collections.emptyMap());
+        lenient().when(mockSigner.sign(isA(Consumer.class))).thenReturn(mockSignedRequest);
+    }
+
+    @Test
+    public void process_withValidRequest_signsRequestAndSetsSignedHeaders() throws Exception
+    {
+        HttpRequest request = new HttpGet(TEST_URI);
+
+        interceptor.process(request, context);
+        assertNotNull("Valid GET request should be processed", request);
+        // Verify that signing occurred
+        verify(mockSigner).sign(isA(Consumer.class));
+    }
+
+    @Test
+    public void process_withInvalidUri_throwsAthenaConnectorException()
+    {
+        HttpRequest request = new BasicHttpRequest(HTTP_METHOD_GET, TEST_URI_INVALID);
+
+        try {
+            interceptor.process(request, context);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Invalid URI",
+                    ex.getMessage().contains(INVALID_URI_MESSAGE));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void process_withEntityEnclosingRequest_signsRequestAndSetsEntityContent() throws Exception
+    {
+        HttpPost request = new HttpPost(TEST_URI);
+        StringEntity entity = new StringEntity(TEST_BODY);
+        request.setEntity(entity);
+
+        interceptor.process(request, context);
+        verify(mockSigner).sign(isA(Consumer.class));
+        assertNotNull("Request entity should be present", request.getEntity());
+        assertEquals("Entity content should match TEST_BODY", TEST_BODY, EntityUtils.toString(request.getEntity()));
+    }
+
+    @Test
+    public void process_withEntityEnclosingRequestWithoutEntity_signsRequestWithEmptyContentStream() throws Exception
+    {
+        HttpPost request = new HttpPost(TEST_URI);
+        // No entity set
+
+        interceptor.process(request, context);
+        verify(mockSigner).sign(isA(Consumer.class));
+        // Implementation only copies entity back when request already had an entity; without entity it may remain null
+        if (request.getEntity() != null) {
+            assertEquals("Entity content stream should be empty", "", EntityUtils.toString(request.getEntity()));
+        }
+    }
+
+    @Test
+    public void process_withNullHostInContext_signsRequestWithoutSettingUri() throws Exception
+    {
+        HttpContext contextWithoutHost = new BasicHttpContext();
+        HttpRequest request = new HttpGet(TEST_URI);
+
+        interceptor.process(request, contextWithoutHost);
+        verify(mockSigner).sign(isA(Consumer.class));
+        assertEquals("Request URI should remain TEST_URI", TEST_URI, request.getRequestLine().getUri());
+    }
+
+    @Test
+    public void process_withQueryParameters_signsRequestWithMultipleValuesForSameKey()
+            throws Exception
+    {
+        // Test nvpToMapParams indirectly through process method by creating a request with query parameters
+        // that have multiple values for the same key
+        String uriWithQueryParams = TEST_URI + "?key1=value1&key1=value2&key2=value3";
+        HttpRequest request = new HttpGet(uriWithQueryParams);
+
+        interceptor.process(request, context);
+
+        verify(mockSigner).sign(isA(Consumer.class));
+        String uri = request.getRequestLine().getUri();
+        assertTrue("Request URI should contain key1=value1", uri.contains("key1=value1"));
+        assertTrue("Request URI should contain key1=value2", uri.contains("key1=value2"));
+        assertTrue("Request URI should contain key2=value3", uri.contains("key2=value3"));
+    }
+
+    @Test
+    public void process_withURISyntaxExceptionInBuilder_throwsAthenaConnectorException()
+    {
+        HttpRequest request = org.mockito.Mockito.mock(HttpRequest.class);
+        org.apache.http.RequestLine requestLine = org.mockito.Mockito.mock(org.apache.http.RequestLine.class);
+        lenient().when(request.getRequestLine()).thenReturn(requestLine);
+        lenient().when(requestLine.getMethod()).thenReturn(HTTP_METHOD_GET);
+        lenient().when(requestLine.getUri()).thenReturn("https://test.com/path?query=value%");
+
+        try {
+            interceptor.process(request, context);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Invalid URI",
+                    ex.getMessage().contains(INVALID_URI_MESSAGE));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
+        }
+    }
+}

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsElasticsearchFactoryTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsElasticsearchFactoryTest.java
@@ -1,0 +1,53 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.elasticsearch;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.services.elasticsearch.ElasticsearchClient;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * This class is used to test the AwsElasticsearchFactory class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AwsElasticsearchFactoryTest
+{
+    @Test
+    public void getClient_returnsElasticsearchClient()
+    {
+        ElasticsearchClient mockClient = mock(ElasticsearchClient.class);
+
+        try (MockedStatic<ElasticsearchClient> elasticsearchClientStaticMock = mockStatic(ElasticsearchClient.class)) {
+            elasticsearchClientStaticMock.when(ElasticsearchClient::create).thenReturn(mockClient);
+
+            AwsElasticsearchFactory factory = new AwsElasticsearchFactory();
+            ElasticsearchClient client = factory.getClient();
+
+            assertNotNull("Elasticsearch client should not be null", client);
+            elasticsearchClientStaticMock.verify(ElasticsearchClient::create);
+        }
+    }
+}

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientFactoryTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientFactoryTest.java
@@ -1,0 +1,142 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.elasticsearch;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class is used to test the AwsRestHighLevelClientFactory class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AwsRestHighLevelClientFactoryTest
+{
+    private static final String TEST_ENDPOINT = "https://search-test.us-east-1.es.amazonaws.com";
+    private static final String TEST_ENDPOINT_WITH_CREDENTIALS = "https://myusername@mypassword:www.example.com";
+    private static final String TEST_USERNAME = "testuser";
+    private static final String TEST_PASSWORD = "testpass";
+
+    @Mock
+    private AwsRestHighLevelClient mockClient;
+
+    private AwsRestHighLevelClientFactory factoryWithAwsCredentials;
+    private AwsRestHighLevelClientFactory factoryWithoutAwsCredentials;
+
+    @Before
+    public void setUp()
+    {
+        factoryWithAwsCredentials = new AwsRestHighLevelClientFactory(true);
+        factoryWithoutAwsCredentials = new AwsRestHighLevelClientFactory(false);
+    }
+
+    @Test
+    public void getOrCreateClient_withAwsCredentials_returnsNonNullClient()
+            throws IOException
+    {
+        try (MockedConstruction<AwsRestHighLevelClient.Builder> construction = mockConstruction(AwsRestHighLevelClient.Builder.class,
+                (mock, context) -> {
+                    when(mock.withCredentials(any())).thenReturn(mock);
+                    when(mock.build()).thenReturn(mockClient);
+                })) {
+            when(mockClient.ping(any())).thenReturn(true);
+            AwsRestHighLevelClient client1 = factoryWithAwsCredentials.getOrCreateClient(TEST_ENDPOINT);
+            AwsRestHighLevelClient client2 = factoryWithAwsCredentials.getOrCreateClient(TEST_ENDPOINT);
+
+            verify(construction.constructed().get(0)).withCredentials(any());
+            verify(construction.constructed().get(0)).build();
+            assertNotNull("Client with AWS credentials should not be null", client1);
+            assertSame("Second call should return cached client", client1, client2);
+            assertEquals("Builder should be constructed only once due to cache", 1, construction.constructed().size());
+        }
+    }
+
+    @Test
+    public void getOrCreateClient_withoutAwsCredentials_returnsBuiltClient()
+            throws IOException
+    {
+        try (MockedConstruction<AwsRestHighLevelClient.Builder> construction = mockConstruction(AwsRestHighLevelClient.Builder.class,
+                (mock, context) -> when(mock.build()).thenReturn(mockClient))) {
+            when(mockClient.ping(any())).thenReturn(true);
+            AwsRestHighLevelClient client1 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT);
+            AwsRestHighLevelClient client2 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT);
+
+            verify(construction.constructed().get(0)).build();
+            assertNotNull("Client without AWS credentials should not be null", client1);
+            assertSame("Second call should return cached client", client1, client2);
+            assertEquals("Builder should be constructed only once due to cache", 1, construction.constructed().size());
+        }
+    }
+
+    @Test
+    public void getOrCreateClient_withEmbeddedCredentials_returnsClientWithCredentials()
+            throws IOException
+    {
+        try (MockedConstruction<AwsRestHighLevelClient.Builder> construction = mockConstruction(AwsRestHighLevelClient.Builder.class,
+                (mock, context) -> {
+                    when(mock.withCredentials(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString())).thenReturn(mock);
+                    when(mock.build()).thenReturn(mockClient);
+                })) {
+            when(mockClient.ping(any())).thenReturn(true);
+            AwsRestHighLevelClient client1 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT_WITH_CREDENTIALS);
+            AwsRestHighLevelClient client2 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT_WITH_CREDENTIALS);
+
+            verify(construction.constructed().get(0)).withCredentials("myusername", "mypassword");
+            verify(construction.constructed().get(0)).build();
+            assertNotNull("Client with embedded credentials should not be null", client1);
+            assertSame("Second call should return cached client", client1, client2);
+            assertEquals("Builder should be constructed only once due to cache", 1, construction.constructed().size());
+        }
+    }
+
+    @Test
+    public void getOrCreateClient_withUsernameAndPassword_returnsClientWithBasicAuth()
+            throws IOException
+    {
+        try (MockedConstruction<AwsRestHighLevelClient.Builder> construction = mockConstruction(AwsRestHighLevelClient.Builder.class,
+                (mock, context) -> {
+                    when(mock.withCredentials(TEST_USERNAME, TEST_PASSWORD)).thenReturn(mock);
+                    when(mock.build()).thenReturn(mockClient);
+                })) {
+            when(mockClient.ping(any())).thenReturn(true);
+            AwsRestHighLevelClient client1 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT, TEST_USERNAME, TEST_PASSWORD);
+            AwsRestHighLevelClient client2 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT, TEST_USERNAME, TEST_PASSWORD);
+
+            verify(construction.constructed().get(0)).withCredentials(TEST_USERNAME, TEST_PASSWORD);
+            verify(construction.constructed().get(0)).build();
+            assertNotNull("Client with username and password should not be null", client1);
+            assertSame("Second call should return cached client", client1, client2);
+            assertEquals("Builder should be constructed only once due to cache", 1, construction.constructed().size());
+        }
+    }
+}

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientFactoryTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientFactoryTest.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.elasticsearch;
 
+import org.elasticsearch.client.RequestOptions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,11 +28,13 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,9 +46,10 @@ import static org.mockito.Mockito.when;
 public class AwsRestHighLevelClientFactoryTest
 {
     private static final String TEST_ENDPOINT = "https://search-test.us-east-1.es.amazonaws.com";
-    private static final String TEST_ENDPOINT_WITH_CREDENTIALS = "https://myusername@mypassword:www.example.com";
     private static final String TEST_USERNAME = "testuser";
     private static final String TEST_PASSWORD = "testpass";
+    private static final String TEST_ENDPOINT_WITH_CREDENTIALS = "https://" + TEST_USERNAME + "@" + TEST_PASSWORD
+            + ":www.example.com";
 
     @Mock
     private AwsRestHighLevelClient mockClient;
@@ -66,14 +70,14 @@ public class AwsRestHighLevelClientFactoryTest
     {
         try (MockedConstruction<AwsRestHighLevelClient.Builder> construction = mockConstruction(AwsRestHighLevelClient.Builder.class,
                 (mock, context) -> {
-                    when(mock.withCredentials(any())).thenReturn(mock);
+                    when(mock.withCredentials(isA(AwsCredentialsProvider.class))).thenReturn(mock);
                     when(mock.build()).thenReturn(mockClient);
                 })) {
-            when(mockClient.ping(any())).thenReturn(true);
+            when(mockClient.ping(eq(RequestOptions.DEFAULT))).thenReturn(true);
             AwsRestHighLevelClient client1 = factoryWithAwsCredentials.getOrCreateClient(TEST_ENDPOINT);
             AwsRestHighLevelClient client2 = factoryWithAwsCredentials.getOrCreateClient(TEST_ENDPOINT);
 
-            verify(construction.constructed().get(0)).withCredentials(any());
+            verify(construction.constructed().get(0)).withCredentials(isA(AwsCredentialsProvider.class));
             verify(construction.constructed().get(0)).build();
             assertNotNull("Client with AWS credentials should not be null", client1);
             assertSame("Second call should return cached client", client1, client2);
@@ -87,7 +91,7 @@ public class AwsRestHighLevelClientFactoryTest
     {
         try (MockedConstruction<AwsRestHighLevelClient.Builder> construction = mockConstruction(AwsRestHighLevelClient.Builder.class,
                 (mock, context) -> when(mock.build()).thenReturn(mockClient))) {
-            when(mockClient.ping(any())).thenReturn(true);
+            when(mockClient.ping(eq(RequestOptions.DEFAULT))).thenReturn(true);
             AwsRestHighLevelClient client1 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT);
             AwsRestHighLevelClient client2 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT);
 
@@ -104,14 +108,14 @@ public class AwsRestHighLevelClientFactoryTest
     {
         try (MockedConstruction<AwsRestHighLevelClient.Builder> construction = mockConstruction(AwsRestHighLevelClient.Builder.class,
                 (mock, context) -> {
-                    when(mock.withCredentials(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString())).thenReturn(mock);
+                    when(mock.withCredentials(TEST_USERNAME, TEST_PASSWORD)).thenReturn(mock);
                     when(mock.build()).thenReturn(mockClient);
                 })) {
-            when(mockClient.ping(any())).thenReturn(true);
+            when(mockClient.ping(eq(RequestOptions.DEFAULT))).thenReturn(true);
             AwsRestHighLevelClient client1 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT_WITH_CREDENTIALS);
             AwsRestHighLevelClient client2 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT_WITH_CREDENTIALS);
 
-            verify(construction.constructed().get(0)).withCredentials("myusername", "mypassword");
+            verify(construction.constructed().get(0)).withCredentials(TEST_USERNAME, TEST_PASSWORD);
             verify(construction.constructed().get(0)).build();
             assertNotNull("Client with embedded credentials should not be null", client1);
             assertSame("Second call should return cached client", client1, client2);
@@ -128,7 +132,7 @@ public class AwsRestHighLevelClientFactoryTest
                     when(mock.withCredentials(TEST_USERNAME, TEST_PASSWORD)).thenReturn(mock);
                     when(mock.build()).thenReturn(mockClient);
                 })) {
-            when(mockClient.ping(any())).thenReturn(true);
+            when(mockClient.ping(eq(RequestOptions.DEFAULT))).thenReturn(true);
             AwsRestHighLevelClient client1 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT, TEST_USERNAME, TEST_PASSWORD);
             AwsRestHighLevelClient client2 = factoryWithoutAwsCredentials.getOrCreateClient(TEST_ENDPOINT, TEST_USERNAME, TEST_PASSWORD);
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientTest.java
@@ -53,8 +53,8 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -156,23 +156,16 @@ public class AwsRestHighLevelClientTest
     }
 
     @Test
-    public void getMapping_whenNoMappingFound_throwsAthenaConnectorException()
+    public void getMapping_whenNoMappingFound_throwsAthenaConnectorException() throws IOException
     {
-        try {
-            when(mockIndicesClient.getMapping(any(GetMappingsRequest.class), eq(RequestOptions.DEFAULT)))
-                    .thenReturn(mockGetMappingsResponse);
-            when(mockGetMappingsResponse.mappings()).thenReturn(Collections.emptyMap());
+        when(mockIndicesClient.getMapping(any(GetMappingsRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockGetMappingsResponse);
+        when(mockGetMappingsResponse.mappings()).thenReturn(Collections.emptyMap());
 
-            client.getMapping(TEST_INDEX);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Could not find mapping",
-                    ex.getMessage().contains("Could not find mapping for data stream name"));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> client.getMapping(TEST_INDEX));
+        assertTrue("Exception message should contain Could not find mapping",
+                ex.getMessage().contains("Could not find mapping for data stream name"));
     }
 
     @Test
@@ -195,22 +188,15 @@ public class AwsRestHighLevelClientTest
     }
 
     @Test
-    public void getAliases_whenExceptionOccurs_throwsAthenaConnectorException()
+    public void getAliases_whenExceptionOccurs_throwsAthenaConnectorException() throws IOException
     {
-        try {
-            when(mockIndicesClient.getAlias(any(GetAliasesRequest.class), eq(RequestOptions.DEFAULT)))
-                    .thenThrow(new IOException(ERROR_MESSAGE));
+        when(mockIndicesClient.getAlias(any(GetAliasesRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenThrow(new IOException(ERROR_MESSAGE));
 
-            client.getAliases();
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain error message",
-                    ex.getMessage().contains(ERROR_MESSAGE));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> client.getAliases());
+        assertTrue("Exception message should contain error message",
+                ex.getMessage().contains(ERROR_MESSAGE));
     }
 
     @Test
@@ -305,14 +291,10 @@ public class AwsRestHighLevelClientTest
                 .thenReturn(mockClusterHealthResponse);
         when(mockClusterHealthResponse.isTimedOut()).thenReturn(true);
 
-        try {
-            client.getShardIds(TEST_INDEX, MAX_SHARDS);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Request timed out",
-                    ex.getMessage().contains("Request timed out"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> client.getShardIds(TEST_INDEX, MAX_SHARDS));
+        assertTrue("Exception message should contain Request timed out",
+                ex.getMessage().contains("Request timed out"));
     }
 
     @Test
@@ -325,14 +307,10 @@ public class AwsRestHighLevelClientTest
         when(mockClusterHealthResponse.isTimedOut()).thenReturn(false);
         when(mockClusterHealthResponse.getActiveShards()).thenReturn(0);
 
-        try {
-            client.getShardIds(TEST_INDEX, MAX_SHARDS);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain no active shards",
-                    ex.getMessage().contains("no active shards"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> client.getShardIds(TEST_INDEX, MAX_SHARDS));
+        assertTrue("Exception message should contain no active shards",
+                ex.getMessage().contains("no active shards"));
     }
 
     @Test
@@ -346,14 +324,10 @@ public class AwsRestHighLevelClientTest
         when(mockClusterHealthResponse.getActiveShards()).thenReturn(5);
         when(mockClusterHealthResponse.getStatus()).thenReturn(ClusterHealthStatus.RED);
 
-        try {
-            client.getShardIds(TEST_INDEX, MAX_SHARDS);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain RED",
-                    ex.getMessage().contains("RED"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> client.getShardIds(TEST_INDEX, MAX_SHARDS));
+        assertTrue("Exception message should contain RED",
+                ex.getMessage().contains("RED"));
     }
 
     @Test
@@ -368,14 +342,10 @@ public class AwsRestHighLevelClientTest
         when(mockClusterHealthResponse.getStatus()).thenReturn(ClusterHealthStatus.GREEN);
         when(mockClusterHealthResponse.getIndices()).thenReturn(Collections.emptyMap());
 
-        try {
-            client.getShardIds(TEST_INDEX, MAX_SHARDS);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain invalid index",
-                    ex.getMessage().contains("invalid index"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> client.getShardIds(TEST_INDEX, MAX_SHARDS));
+        assertTrue("Exception message should contain invalid index",
+                ex.getMessage().contains("invalid index"));
     }
 
     @Test

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientTest.java
@@ -1,0 +1,412 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.elasticsearch;
+
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.GetAliasesResponse;
+import org.elasticsearch.client.ClusterClient;
+import org.elasticsearch.client.IndicesClient;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.health.ClusterIndexHealth;
+import org.elasticsearch.cluster.health.ClusterShardHealth;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.search.SearchHit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class is used to test the AwsRestHighLevelClient class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AwsRestHighLevelClientTest
+{
+    private static final String TEST_INDEX = "test-index";
+    private static final String ERROR_MESSAGE = "Test error message";
+    private static final String TEST_ENDPOINT = "https://search-test.us-east-1.es.amazonaws.com";
+    private static final String ALIAS1 = "alias1";
+    private static final String ALIAS2 = "alias2";
+    private static final String PROPERTIES = "properties";
+    private static final int MAX_SHARDS = 10;
+
+    @Mock
+    private RestClientBuilder mockRestClientBuilder;
+
+    @Mock
+    private IndicesClient mockIndicesClient;
+
+    @Mock
+    private GetMappingsResponse mockGetMappingsResponse;
+
+    @Mock
+    private GetAliasesResponse mockGetAliasesResponse;
+
+    @Mock
+    private MappingMetadata mockMappingMetadata;
+
+    @Mock
+    private SearchResponse mockSearchResponse;
+
+    @Mock
+    private SearchHit mockSearchHit;
+
+    @Mock
+    private ClusterClient mockClusterClient;
+
+    @Mock
+    private ClusterHealthResponse mockClusterHealthResponse;
+
+    private AwsRestHighLevelClient client;
+
+    @Before
+    public void setUp()
+    {
+        RestClient mockRestClient = org.mockito.Mockito.mock(RestClient.class);
+        when(mockRestClientBuilder.build()).thenReturn(mockRestClient);
+        client = org.mockito.Mockito.spy(new AwsRestHighLevelClient(mockRestClientBuilder));
+        when(client.indices()).thenReturn(mockIndicesClient);
+    }
+
+
+    @Test
+    public void getMapping_withRegularIndex_returnsMapping() throws Exception
+    {
+        LinkedHashMap<String, Object> expectedMapping = new LinkedHashMap<>();
+        expectedMapping.put(PROPERTIES, new LinkedHashMap<>());
+
+        Map<String, MappingMetadata> mappingsMap = new LinkedHashMap<>();
+        when(mockMappingMetadata.getSourceAsMap()).thenReturn(expectedMapping);
+        mappingsMap.put(TEST_INDEX, mockMappingMetadata);
+
+        when(mockIndicesClient.getMapping(any(GetMappingsRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockGetMappingsResponse);
+        when(mockGetMappingsResponse.mappings()).thenReturn(mappingsMap);
+
+        LinkedHashMap<String, Object> result = client.getMapping(TEST_INDEX);
+
+        assertNotNull("Mapping for regular index should not be null", result);
+        assertEquals("Mapping for regular index should match expected", expectedMapping, result);
+    }
+
+    @Test
+    public void getMapping_withDataStream_returnsFirstAvailableMapping() throws Exception
+    {
+        LinkedHashMap<String, Object> expectedMapping = new LinkedHashMap<>();
+        expectedMapping.put(PROPERTIES, new LinkedHashMap<>());
+
+        Map<String, MappingMetadata> mappingsMap = new LinkedHashMap<>();
+        MappingMetadata dsMappingMetadata = org.mockito.Mockito.mock(MappingMetadata.class);
+        when(dsMappingMetadata.getSourceAsMap()).thenReturn(expectedMapping);
+        mappingsMap.put(".ds-test-datastream-000001", dsMappingMetadata);
+
+        when(mockIndicesClient.getMapping(any(GetMappingsRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockGetMappingsResponse);
+        when(mockGetMappingsResponse.mappings()).thenReturn(mappingsMap);
+
+        LinkedHashMap<String, Object> result = client.getMapping("test-datastream");
+
+        assertNotNull("Mapping for data stream should not be null", result);
+        assertEquals("Mapping for data stream should match expected", expectedMapping, result);
+    }
+
+    @Test
+    public void getMapping_whenNoMappingFound_throwsAthenaConnectorException()
+    {
+        try {
+            when(mockIndicesClient.getMapping(any(GetMappingsRequest.class), eq(RequestOptions.DEFAULT)))
+                    .thenReturn(mockGetMappingsResponse);
+            when(mockGetMappingsResponse.mappings()).thenReturn(Collections.emptyMap());
+
+            client.getMapping(TEST_INDEX);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Could not find mapping",
+                    ex.getMessage().contains("Could not find mapping for data stream name"));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void getAliases_withValidRequest_returnsAliases() throws Exception
+    {
+        Map<String, Set<AliasMetadata>> aliasesMap = new LinkedHashMap<>();
+        aliasesMap.put(ALIAS1, Collections.emptySet());
+        aliasesMap.put(ALIAS2, Collections.emptySet());
+
+        when(mockIndicesClient.getAlias(any(GetAliasesRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockGetAliasesResponse);
+        when(mockGetAliasesResponse.getAliases()).thenReturn(aliasesMap);
+
+        Set<String> aliases = client.getAliases();
+
+        assertNotNull("Aliases from valid request should not be null", aliases);
+        assertEquals("Should have 2 aliases from valid request", 2, aliases.size());
+        assertTrue("Should contain alias1 from valid request", aliases.contains(ALIAS1));
+        assertTrue("Should contain alias2 from valid request", aliases.contains(ALIAS2));
+    }
+
+    @Test
+    public void getAliases_whenExceptionOccurs_throwsAthenaConnectorException()
+    {
+        try {
+            when(mockIndicesClient.getAlias(any(GetAliasesRequest.class), eq(RequestOptions.DEFAULT)))
+                    .thenThrow(new IOException(ERROR_MESSAGE));
+
+            client.getAliases();
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error message",
+                    ex.getMessage().contains(ERROR_MESSAGE));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void getDocuments_withValidRequest_returnsSearchResponse() throws Exception
+    {
+        SearchRequest request = new SearchRequest(TEST_INDEX);
+        doReturn(mockSearchResponse).when(client).search(any(SearchRequest.class), eq(RequestOptions.DEFAULT));
+
+        SearchResponse response = client.getDocuments(request);
+
+        assertNotNull("Search response from valid request should not be null", response);
+        assertEquals("Search response from valid request should match expected", mockSearchResponse, response);
+    }
+
+    @Test
+    public void getDocument_withSearchHit_returnsDocumentMap()
+    {
+        Map<String, Object> expectedDocument = new LinkedHashMap<>();
+        expectedDocument.put("field1", "value1");
+        expectedDocument.put("field2", "value2");
+
+        when(mockSearchHit.getSourceAsMap()).thenReturn(expectedDocument);
+
+        Map<String, Object> document = client.getDocument(mockSearchHit);
+
+        assertNotNull("Document from search hit should not be null", document);
+        assertEquals("Document from search hit should match expected", expectedDocument, document);
+    }
+
+    @Test
+    public void builder_constructor_createsBuilder()
+    {
+        AwsRestHighLevelClient.Builder builder = new AwsRestHighLevelClient.Builder(TEST_ENDPOINT);
+
+        assertNotNull("Builder from constructor should not be null", builder);
+    }
+
+    @Test
+    public void builder_withAwsCredentials_returnsBuilderWithAwsSigningInterceptor()
+    {
+        AwsRestHighLevelClient.Builder builder = new AwsRestHighLevelClient.Builder(TEST_ENDPOINT);
+        software.amazon.awssdk.auth.credentials.AwsCredentialsProvider credentialsProvider =
+                mock(software.amazon.awssdk.auth.credentials.AwsCredentialsProvider.class);
+
+        AwsRestHighLevelClient.Builder result = builder.withCredentials(credentialsProvider);
+
+        assertNotNull("Result should not be null", result);
+        assertEquals("Builder with AWS credentials should return self", builder, result);
+    }
+
+    @Test
+    public void builder_withAwsCredentials_returnsSameBuilderInstance()
+    {
+        String endpoint = "https://test";
+        AwsRestHighLevelClient.Builder builder = new AwsRestHighLevelClient.Builder(endpoint);
+        software.amazon.awssdk.auth.credentials.AwsCredentialsProvider credentialsProvider =
+                mock(software.amazon.awssdk.auth.credentials.AwsCredentialsProvider.class);
+
+        AwsRestHighLevelClient.Builder result = builder.withCredentials(credentialsProvider);
+
+        assertNotNull("Builder withCredentials result should not be null", result);
+        assertEquals("withCredentials should return same builder instance", builder, result);
+    }
+
+    @Test
+    public void builder_withUsernamePassword_returnsBuilderWithBasicAuthProvider()
+    {
+        AwsRestHighLevelClient.Builder builder = new AwsRestHighLevelClient.Builder(TEST_ENDPOINT);
+
+        AwsRestHighLevelClient.Builder result = builder.withCredentials("testuser", "testpass");
+
+        assertNotNull("Result from builder with username and password should not be null", result);
+        assertEquals("Builder with username and password should return self", builder, result);
+    }
+
+    @Test
+    public void builder_build_returnsClient()
+    {
+        AwsRestHighLevelClient.Builder builder = new AwsRestHighLevelClient.Builder(TEST_ENDPOINT);
+
+        AwsRestHighLevelClient client = builder.build();
+
+        assertNotNull("Client from builder build should not be null", client);
+    }
+
+    @Test
+    public void getShardIds_whenClusterHealthTimesOut_throwsAthenaConnectorException()
+            throws Exception
+    {
+        when(client.cluster()).thenReturn(mockClusterClient);
+        when(mockClusterClient.health(any(ClusterHealthRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockClusterHealthResponse);
+        when(mockClusterHealthResponse.isTimedOut()).thenReturn(true);
+
+        try {
+            client.getShardIds(TEST_INDEX, MAX_SHARDS);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Request timed out",
+                    ex.getMessage().contains("Request timed out"));
+        }
+    }
+
+    @Test
+    public void getShardIds_whenActiveShardsZero_throwsAthenaConnectorException()
+            throws Exception
+    {
+        when(client.cluster()).thenReturn(mockClusterClient);
+        when(mockClusterClient.health(any(ClusterHealthRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockClusterHealthResponse);
+        when(mockClusterHealthResponse.isTimedOut()).thenReturn(false);
+        when(mockClusterHealthResponse.getActiveShards()).thenReturn(0);
+
+        try {
+            client.getShardIds(TEST_INDEX, MAX_SHARDS);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain no active shards",
+                    ex.getMessage().contains("no active shards"));
+        }
+    }
+
+    @Test
+    public void getShardIds_whenClusterStatusRed_throwsAthenaConnectorException()
+            throws Exception
+    {
+        when(client.cluster()).thenReturn(mockClusterClient);
+        when(mockClusterClient.health(any(ClusterHealthRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockClusterHealthResponse);
+        when(mockClusterHealthResponse.isTimedOut()).thenReturn(false);
+        when(mockClusterHealthResponse.getActiveShards()).thenReturn(5);
+        when(mockClusterHealthResponse.getStatus()).thenReturn(ClusterHealthStatus.RED);
+
+        try {
+            client.getShardIds(TEST_INDEX, MAX_SHARDS);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain RED",
+                    ex.getMessage().contains("RED"));
+        }
+    }
+
+    @Test
+    public void getShardIds_whenIndexNotFound_throwsAthenaConnectorException()
+            throws Exception
+    {
+        when(client.cluster()).thenReturn(mockClusterClient);
+        when(mockClusterClient.health(any(ClusterHealthRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockClusterHealthResponse);
+        when(mockClusterHealthResponse.isTimedOut()).thenReturn(false);
+        when(mockClusterHealthResponse.getActiveShards()).thenReturn(5);
+        when(mockClusterHealthResponse.getStatus()).thenReturn(ClusterHealthStatus.GREEN);
+        when(mockClusterHealthResponse.getIndices()).thenReturn(Collections.emptyMap());
+
+        try {
+            client.getShardIds(TEST_INDEX, MAX_SHARDS);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain invalid index",
+                    ex.getMessage().contains("invalid index"));
+        }
+    }
+
+    @Test
+    public void getShardIds_withValidIndex_returnsShardIds()
+            throws Exception
+    {
+        Map<Integer, ClusterShardHealth> shards = new LinkedHashMap<>();
+        ClusterShardHealth shard1 = org.mockito.Mockito.mock(ClusterShardHealth.class);
+        ClusterShardHealth shard2 = org.mockito.Mockito.mock(ClusterShardHealth.class);
+        shards.put(0, shard1);
+        shards.put(1, shard2);
+
+        ClusterIndexHealth indexHealth = org.mockito.Mockito.mock(ClusterIndexHealth.class);
+        when(indexHealth.getShards()).thenReturn(shards);
+
+        Map<String, ClusterIndexHealth> indices = new LinkedHashMap<>();
+        indices.put(TEST_INDEX, indexHealth);
+
+        when(client.cluster()).thenReturn(mockClusterClient);
+        when(mockClusterClient.health(any(ClusterHealthRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockClusterHealthResponse);
+        when(mockClusterHealthResponse.isTimedOut()).thenReturn(false);
+        when(mockClusterHealthResponse.getActiveShards()).thenReturn(5);
+        when(mockClusterHealthResponse.getStatus()).thenReturn(ClusterHealthStatus.GREEN);
+        when(mockClusterHealthResponse.getIndices()).thenReturn(indices);
+
+        Set<Integer> result = client.getShardIds(TEST_INDEX, MAX_SHARDS);
+
+        assertNotNull("Shard IDs from valid index should not be null", result);
+        assertEquals("Should have 2 shards from valid index", 2, result.size());
+        assertTrue("Should contain shard 0 from valid index", result.contains(0));
+        assertTrue("Should contain shard 1 from valid index", result.contains(1));
+    }
+}

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/CacheableAwsRestHighLevelClientTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/CacheableAwsRestHighLevelClientTest.java
@@ -34,6 +34,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -43,6 +47,8 @@ import static org.mockito.Mockito.when;
 public class CacheableAwsRestHighLevelClientTest
 {
     private static final Logger logger = LoggerFactory.getLogger(CacheableAwsRestHighLevelClientTest.class);
+    private static final String ENDPOINT_1 = "endpoint1";
+    private static final String ENDPOINT_2 = "endpoint2";
 
     private CacheableAwsRestHighLevelClient clientCache;
 
@@ -62,76 +68,77 @@ public class CacheableAwsRestHighLevelClientTest
      * Test the cache's ability to return the correct client.
      */
     @Test
-    public void getClientSimpleTest()
+    public void get_withMultipleEndpoints_returnsCachedClientPerEndpoint()
             throws IOException
     {
-        logger.info("getClientSimpleTest - enter");
+        logger.info("get_withMultipleEndpoints_returnsCachedClientPerEndpoint - enter");
 
-        clientCache.put("endpoint1", client1);
-        clientCache.put("endpoint2", client2);
+        clientCache.put(ENDPOINT_1, client1);
+        clientCache.put(ENDPOINT_2, client2);
 
         when(client1.ping(RequestOptions.DEFAULT)).thenReturn(true);
         when(client2.ping(RequestOptions.DEFAULT)).thenReturn(true);
 
         assertEquals("Cache has wrong number of clients.", 2, clientCache.size());
-        assertNotNull("Cache get() method returned null.", clientCache.get("endpoint1"));
-        assertNotNull("Cache get() method returned null.", clientCache.get("endpoint2"));
-        assertEquals("Wrong client returned from cache.", client1, clientCache.get("endpoint1"));
-        assertEquals("Wrong client returned from cache.", client2, clientCache.get("endpoint2"));
+        assertNotNull("Cache get() method returned null.", clientCache.get(ENDPOINT_1));
+        assertNotNull("Cache get() method returned null.", clientCache.get(ENDPOINT_2));
+        assertEquals("Wrong client returned from cache.", client1, clientCache.get(ENDPOINT_1));
+        assertEquals("Wrong client returned from cache.", client2, clientCache.get(ENDPOINT_2));
 
-        logger.info("getClientSimpleTest - exit");
+        logger.info("get_withMultipleEndpoints_returnsCachedClientPerEndpoint - exit");
     }
 
     /**
      * Test the cache's ability to evict clients that have aged out (as indicated by MAX_CACHE_AGE_MS).
      */
     @Test
-    public void evictOldClientTest()
+    public void get_whenClientExceedsMaxCacheAge_evictsClient()
             throws IOException
     {
-        logger.info("evictOldClientTest - enter");
+        logger.info("get_whenClientExceedsMaxCacheAge_evictsClient - enter");
 
+        lenient().when(client1.ping(any())).thenReturn(true);
         // Test eviction on the get() method.
-        clientCache.addClientEntry("endpoint1", client1, System.currentTimeMillis() -
+        clientCache.addClientEntry(ENDPOINT_1, client1, System.currentTimeMillis() -
                 CacheableAwsRestHighLevelClient.MAX_CACHE_AGE_MS - 1);
 
         assertEquals("Cache has wrong number of clients.", 1, clientCache.size());
-        assertNull("Invalid value returned from cache.", clientCache.get("endpoint1"));
+        assertNull("Invalid value returned from cache.", clientCache.get(ENDPOINT_1));
         assertEquals("Cache has wrong number of clients.", 0, clientCache.size());
 
         // Test eviction on the put() method.
-        when(client2.ping(any())).thenReturn(true);
-        clientCache.addClientEntry("endpoint1", client1, System.currentTimeMillis() -
+        lenient().when(client2.ping(any())).thenReturn(true);
+        clientCache.addClientEntry(ENDPOINT_1, client1, System.currentTimeMillis() -
                 CacheableAwsRestHighLevelClient.MAX_CACHE_AGE_MS - 1);
 
         assertEquals("Cache has wrong number of clients.", 1, clientCache.size());
 
-        clientCache.put("endpoint2", client2);
+        clientCache.put(ENDPOINT_2, client2);
 
         assertEquals("Cache has wrong number of clients.", 1, clientCache.size());
-        assertNotNull("Cache get() method returned null.", clientCache.get("endpoint2"));
-        assertEquals("Wrong client returned from cache.", client2, clientCache.get("endpoint2"));
+        assertNotNull("Cache get() method returned null.", clientCache.get(ENDPOINT_2));
+        assertEquals("Wrong client returned from cache.", client2, clientCache.get(ENDPOINT_2));
 
-        logger.info("evictOldClientTest - exit");
+        logger.info("get_whenClientExceedsMaxCacheAge_evictsClient - exit");
     }
 
     /**
      * Test the cache's ability to evict unhealthy clients.
      */
     @Test
-    public void evictUnhealthyClientTest()
+    public void get_whenClientPingFails_evictsUnhealthyClient()
             throws IOException
     {
-        logger.info("evictUnhealthyClientTest - enter");
+        logger.info("get_whenClientPingFails_evictsUnhealthyClient - enter");
 
         when(client1.ping(any())).thenReturn(false);
-        clientCache.put("endpoint1", client1);
+        clientCache.put(ENDPOINT_1, client1);
 
         assertEquals("Cache has wrong number of clients.", 1, clientCache.size());
-        assertNull("Invalid value returned from cache.", clientCache.get("endpoint1"));
+        assertNull("Invalid value returned from cache.", clientCache.get(ENDPOINT_1));
         assertEquals("Cache has wrong number of clients.", 0, clientCache.size());
 
-        logger.info("evictUnhealthyClientTest - exit");
+        logger.info("get_whenClientPingFails_evictsUnhealthyClient - exit");
     }
 
     /**
@@ -139,11 +146,13 @@ public class CacheableAwsRestHighLevelClientTest
      * MAX_CACHE_SIZE).
      */
     @Test
-    public void evictExceededCapacityClientTest()
+    public void put_whenCapacityExceeded_evictsOldestClient()
+            throws IOException
     {
-        logger.info("evictExceededCapacityClientTest - enter");
+        logger.info("put_whenCapacityExceeded_evictsOldestClient - enter");
 
-        clientCache.put("endpoint1", client1);
+        lenient().when(client1.ping(any())).thenReturn(true);
+        clientCache.put(ENDPOINT_1, client1);
         for (int i = 0; i < CacheableAwsRestHighLevelClient.MAX_CACHE_SIZE; ++i) {
             String endpoint = "newendpoint" + i;
             clientCache.put(endpoint, client2);
@@ -151,8 +160,53 @@ public class CacheableAwsRestHighLevelClientTest
 
         assertEquals("Cache has wrong number of clients.",
                 CacheableAwsRestHighLevelClient.MAX_CACHE_SIZE, clientCache.size());
-        assertNull("Invalid value returned from cache.", clientCache.get("endpoint1"));
+        assertNull("Invalid value returned from cache.", clientCache.get(ENDPOINT_1));
 
-        logger.info("evictExceededCapacityClientTest - exit");
+        logger.info("put_whenCapacityExceeded_evictsOldestClient - exit");
+    }
+
+    @Test
+    public void get_withUnhealthyClient_evictsClientAndClosesIt()
+            throws IOException
+    {
+        clientCache.put(ENDPOINT_1, client1);
+        clientCache.put(ENDPOINT_2, client2);
+
+        assertEquals("Cache should have 2 clients before get", 2, clientCache.size());
+
+        // Make client1 unhealthy - get() will call evictCache(endpoint) internally
+        when(client1.ping(any())).thenThrow(new IOException("Connection failed"));
+        when(client2.ping(any())).thenReturn(true);
+
+        // get() will detect unhealthy client and evict it
+        assertNull("get() should return null for unhealthy client", clientCache.get(ENDPOINT_1));
+
+        assertEquals("Cache should have 1 client after eviction", 1, clientCache.size());
+
+        // Verify that client1 was closed during eviction
+        verify(client1, times(1)).close();
+
+        // Verify that client2 is still accessible after selective eviction
+        assertNotNull("Healthy client should still be accessible", clientCache.get(ENDPOINT_2));
+        assertEquals("get() should return client2 for endpoint2", client2, clientCache.get(ENDPOINT_2));
+    }
+
+    @Test
+    public void get_whenUnhealthyClientCloseThrowsIOException_evictsClientWithoutRethrowing()
+            throws IOException
+    {
+        doThrow(new IOException("Close failed")).when(client1).close();
+        clientCache.put(ENDPOINT_1, client1);
+
+        // Make client unhealthy - get() will call evictCache(endpoint) internally, which calls closeClient
+        when(client1.ping(any())).thenThrow(new IOException("Connection failed"));
+
+        // get() will detect unhealthy client and evict it (closeClient may throw IOException but should be handled)
+        clientCache.get(ENDPOINT_1);
+
+        assertEquals("Cache should be empty after eviction", 0, clientCache.size());
+
+        // Verify that close() was invoked during eviction
+        verify(client1, times(1)).close();
     }
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/CacheableAwsRestHighLevelClientTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/CacheableAwsRestHighLevelClientTest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -97,7 +97,7 @@ public class CacheableAwsRestHighLevelClientTest
     {
         logger.info("get_whenClientExceedsMaxCacheAge_evictsClient - enter");
 
-        lenient().when(client1.ping(any())).thenReturn(true);
+        lenient().when(client1.ping(eq(RequestOptions.DEFAULT))).thenReturn(true);
         // Test eviction on the get() method.
         clientCache.addClientEntry(ENDPOINT_1, client1, System.currentTimeMillis() -
                 CacheableAwsRestHighLevelClient.MAX_CACHE_AGE_MS - 1);
@@ -107,7 +107,7 @@ public class CacheableAwsRestHighLevelClientTest
         assertEquals("Cache has wrong number of clients.", 0, clientCache.size());
 
         // Test eviction on the put() method.
-        lenient().when(client2.ping(any())).thenReturn(true);
+        lenient().when(client2.ping(eq(RequestOptions.DEFAULT))).thenReturn(true);
         clientCache.addClientEntry(ENDPOINT_1, client1, System.currentTimeMillis() -
                 CacheableAwsRestHighLevelClient.MAX_CACHE_AGE_MS - 1);
 
@@ -131,7 +131,7 @@ public class CacheableAwsRestHighLevelClientTest
     {
         logger.info("get_whenClientPingFails_evictsUnhealthyClient - enter");
 
-        when(client1.ping(any())).thenReturn(false);
+        when(client1.ping(eq(RequestOptions.DEFAULT))).thenReturn(false);
         clientCache.put(ENDPOINT_1, client1);
 
         assertEquals("Cache has wrong number of clients.", 1, clientCache.size());
@@ -151,7 +151,7 @@ public class CacheableAwsRestHighLevelClientTest
     {
         logger.info("put_whenCapacityExceeded_evictsOldestClient - enter");
 
-        lenient().when(client1.ping(any())).thenReturn(true);
+        lenient().when(client1.ping(eq(RequestOptions.DEFAULT))).thenReturn(true);
         clientCache.put(ENDPOINT_1, client1);
         for (int i = 0; i < CacheableAwsRestHighLevelClient.MAX_CACHE_SIZE; ++i) {
             String endpoint = "newendpoint" + i;
@@ -175,8 +175,8 @@ public class CacheableAwsRestHighLevelClientTest
         assertEquals("Cache should have 2 clients before get", 2, clientCache.size());
 
         // Make client1 unhealthy - get() will call evictCache(endpoint) internally
-        when(client1.ping(any())).thenThrow(new IOException("Connection failed"));
-        when(client2.ping(any())).thenReturn(true);
+        when(client1.ping(eq(RequestOptions.DEFAULT))).thenThrow(new IOException("Connection failed"));
+        when(client2.ping(eq(RequestOptions.DEFAULT))).thenReturn(true);
 
         // get() will detect unhealthy client and evict it
         assertNull("get() should return null for unhealthy client", clientCache.get(ENDPOINT_1));
@@ -199,7 +199,7 @@ public class CacheableAwsRestHighLevelClientTest
         clientCache.put(ENDPOINT_1, client1);
 
         // Make client unhealthy - get() will call evictCache(endpoint) internally, which calls closeClient
-        when(client1.ping(any())).thenThrow(new IOException("Connection failed"));
+        when(client1.ping(eq(RequestOptions.DEFAULT))).thenThrow(new IOException("Connection failed"));
 
         // get() will detect unhealthy client and evict it (closeClient may throw IOException but should be handled)
         clientCache.get(ENDPOINT_1);

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchDomainMapProviderTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchDomainMapProviderTest.java
@@ -40,8 +40,8 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -137,14 +137,10 @@ public class ElasticsearchDomainMapProviderTest
     {
         ElasticsearchDomainMapProvider domainMapProvider = new ElasticsearchDomainMapProvider(false);
 
-        try {
-            domainMapProvider.getDomainMap("");
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Empty or null value",
-                    ex.getMessage().contains("Empty or null value found in DomainMapping"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> domainMapProvider.getDomainMap(""));
+        assertTrue("Exception message should contain Empty or null value",
+                ex.getMessage().contains("Empty or null value found in DomainMapping"));
     }
 
     @Test
@@ -152,14 +148,10 @@ public class ElasticsearchDomainMapProviderTest
     {
         ElasticsearchDomainMapProvider domainMapProvider = new ElasticsearchDomainMapProvider(false);
 
-        try {
-            domainMapProvider.getDomainMap(null);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Empty or null value",
-                    ex.getMessage().contains("Empty or null value found in DomainMapping"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> domainMapProvider.getDomainMap(null));
+        assertTrue("Exception message should contain Empty or null value",
+                ex.getMessage().contains("Empty or null value found in DomainMapping"));
     }
 
     @Test
@@ -180,14 +172,10 @@ public class ElasticsearchDomainMapProviderTest
         ElasticsearchDomainMapProvider domainMapProvider = new ElasticsearchDomainMapProvider(false);
         String invalidDomainMapping = "invalid=format=with=too=many=equals";
 
-        try {
-            domainMapProvider.getDomainMap(invalidDomainMapping);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Parsing error",
-                    ex.getMessage().contains("DomainMapping Parsing error"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> domainMapProvider.getDomainMap(invalidDomainMapping));
+        assertTrue("Exception message should contain Parsing error",
+                ex.getMessage().contains("DomainMapping Parsing error"));
     }
 
     @Test
@@ -222,14 +210,10 @@ public class ElasticsearchDomainMapProviderTest
         when(mockClient.describeElasticsearchDomains(any(DescribeElasticsearchDomainsRequest.class)))
                 .thenThrow(new RuntimeException("Describe domains failed"));
 
-        try {
-            domainProvider.getDomainMap(null);
-            fail("Expected RuntimeException was not thrown");
-        }
-        catch (RuntimeException ex) {
-            assertTrue("Exception message should contain Describe domains failed",
-                    ex.getMessage().contains("Describe domains failed"));
-        }
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> domainProvider.getDomainMap(null));
+        assertTrue("Exception message should contain Describe domains failed",
+                ex.getMessage().contains("Describe domains failed"));
     }
 
     @Test
@@ -245,14 +229,10 @@ public class ElasticsearchDomainMapProviderTest
         when(mockClient.listDomainNames()).thenReturn(mockDomainInfo);
         when(mockDomainInfo.domainNames()).thenReturn(ImmutableList.of());
 
-        try {
-            domainProvider.getDomainMap(null);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain no domain information",
-                    ex.getMessage().contains("no domain information"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> domainProvider.getDomainMap(null));
+        assertTrue("Exception message should contain no domain information",
+                ex.getMessage().contains("no domain information"));
     }
 
     @Test

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchDomainMapProviderTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchDomainMapProviderTest.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.elasticsearch;
 
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,10 +38,14 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * This class is used to test the ElasticsearchDomainMapProvider class.
@@ -55,9 +60,9 @@ public class ElasticsearchDomainMapProviderTest
      * associated endpoints.
      */
     @Test
-    public void getDomainMapFromEnvironmentVarTest()
+    public void getDomainMap_withEnvironmentVar_returnsDomainMap()
     {
-        logger.info("getDomainMapFromEnvironmentVarTest - enter");
+        logger.info("getDomainMap_withEnvironmentVar_returnsDomainMap - enter");
 
         ElasticsearchDomainMapProvider domainMapProvider = new ElasticsearchDomainMapProvider(false);
         String domainMapping = "domain1=myusername@password:www.endpoint1.com,domain2=myusername@password:www.endpoint2.com";
@@ -71,13 +76,13 @@ public class ElasticsearchDomainMapProviderTest
         assertEquals("Invalid value for domain2:", "myusername@password:www.endpoint2.com",
                 domainMap.get("domain2"));
 
-        logger.info("getDomainMapFromEnvironmentVarTest - exit");
+        logger.info("getDomainMap_withEnvironmentVar_returnsDomainMap - exit");
     }
 
     @Test
-    public void getDomainMapFromAwsElasticsearchTest()
+    public void getDomainMap_fromAwsElasticsearch_returnsDomainMap()
     {
-        logger.info("getDomainMapFromAwsElasticsearchTest - enter");
+        logger.info("getDomainMap_fromAwsElasticsearch_returnsDomainMap - enter");
 
         AwsElasticsearchFactory mockElasticsearchFactory = mock(AwsElasticsearchFactory.class);
         ElasticsearchDomainMapProvider domainProvider =
@@ -124,6 +129,166 @@ public class ElasticsearchDomainMapProviderTest
                     domainMap.get(domainName));
         });
 
-        logger.info("getDomainMapFromAwsElasticsearchTest - exit");
+        logger.info("getDomainMap_fromAwsElasticsearch_returnsDomainMap - exit");
+    }
+
+    @Test
+    public void getDomainMap_withEmptyString_throwsAthenaConnectorException()
+    {
+        ElasticsearchDomainMapProvider domainMapProvider = new ElasticsearchDomainMapProvider(false);
+
+        try {
+            domainMapProvider.getDomainMap("");
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Empty or null value",
+                    ex.getMessage().contains("Empty or null value found in DomainMapping"));
+        }
+    }
+
+    @Test
+    public void getDomainMap_withNullString_throwsAthenaConnectorException()
+    {
+        ElasticsearchDomainMapProvider domainMapProvider = new ElasticsearchDomainMapProvider(false);
+
+        try {
+            domainMapProvider.getDomainMap(null);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Empty or null value",
+                    ex.getMessage().contains("Empty or null value found in DomainMapping"));
+        }
+    }
+
+    @Test
+    public void getDomainMap_withSingleDomainMapping_returnsSingleEntryMap()
+    {
+        ElasticsearchDomainMapProvider domainMapProvider = new ElasticsearchDomainMapProvider(false);
+        String domainMapping = "domain1=myusername@password:www.endpoint1.com";
+        Map<String, String> domainMap = domainMapProvider.getDomainMap(domainMapping);
+
+        assertEquals("Invalid number of elements in map:", 1, domainMap.size());
+        assertEquals("Invalid value for domain1:", "myusername@password:www.endpoint1.com",
+                domainMap.get("domain1"));
+    }
+
+    @Test
+    public void getDomainMap_withParsingError_throwsAthenaConnectorException()
+    {
+        ElasticsearchDomainMapProvider domainMapProvider = new ElasticsearchDomainMapProvider(false);
+        String invalidDomainMapping = "invalid=format=with=too=many=equals";
+
+        try {
+            domainMapProvider.getDomainMap(invalidDomainMapping);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Parsing error",
+                    ex.getMessage().contains("DomainMapping Parsing error"));
+        }
+    }
+
+    @Test
+    public void getDomainMap_withInvalidFormat_returnsMapWithEmptyKeys()
+    {
+        // ElasticsearchDomainMapProvider.getDomainMap currently produces a map {"": ""} for input "=".
+        ElasticsearchDomainMapProvider domainMapProvider = new ElasticsearchDomainMapProvider(false);
+        String invalidDomainMapping = "=";
+
+        Map<String, String> domainMap = domainMapProvider.getDomainMap(invalidDomainMapping);
+
+        assertNotNull("Domain map should not be null for invalid format", domainMap);
+        assertFalse("Domain map should not be empty for single equals input", domainMap.isEmpty());
+        assertTrue("Domain map should contain empty key", domainMap.containsKey(""));
+        assertEquals("Domain map value for empty key should be empty string", "", domainMap.get(""));
+    }
+
+    @Test
+    public void getDomainMap_fromAwsElasticsearchWhenDescribeDomainsThrows_propagatesException()
+    {
+        AwsElasticsearchFactory mockElasticsearchFactory = mock(AwsElasticsearchFactory.class);
+        ElasticsearchDomainMapProvider domainProvider =
+                new ElasticsearchDomainMapProvider(true, mockElasticsearchFactory);
+        ElasticsearchClient mockClient = mock(ElasticsearchClient.class);
+        ListDomainNamesResponse mockDomainInfo = mock(ListDomainNamesResponse.class);
+        List<DomainInfo> domainInfo = new ArrayList<>();
+        domainInfo.add(DomainInfo.builder().domainName("domain1").build());
+
+        when(mockElasticsearchFactory.getClient()).thenReturn(mockClient);
+        when(mockClient.listDomainNames()).thenReturn(mockDomainInfo);
+        when(mockDomainInfo.domainNames()).thenReturn(domainInfo);
+        when(mockClient.describeElasticsearchDomains(any(DescribeElasticsearchDomainsRequest.class)))
+                .thenThrow(new RuntimeException("Describe domains failed"));
+
+        try {
+            domainProvider.getDomainMap(null);
+            fail("Expected RuntimeException was not thrown");
+        }
+        catch (RuntimeException ex) {
+            assertTrue("Exception message should contain Describe domains failed",
+                    ex.getMessage().contains("Describe domains failed"));
+        }
+    }
+
+    @Test
+    public void getDomainMap_fromAwsElasticsearchWithEmptyDomainList_throwsAthenaConnectorException()
+    {
+        AwsElasticsearchFactory mockElasticsearchFactory = mock(AwsElasticsearchFactory.class);
+        ElasticsearchDomainMapProvider domainProvider =
+                new ElasticsearchDomainMapProvider(true, mockElasticsearchFactory);
+        ElasticsearchClient mockClient = mock(ElasticsearchClient.class);
+        ListDomainNamesResponse mockDomainInfo = mock(ListDomainNamesResponse.class);
+
+        when(mockElasticsearchFactory.getClient()).thenReturn(mockClient);
+        when(mockClient.listDomainNames()).thenReturn(mockDomainInfo);
+        when(mockDomainInfo.domainNames()).thenReturn(ImmutableList.of());
+
+        try {
+            domainProvider.getDomainMap(null);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain no domain information",
+                    ex.getMessage().contains("no domain information"));
+        }
+    }
+
+    @Test
+    public void getDomainMap_fromAwsElasticsearchWithNullEndpoint_usesVpcEndpoint()
+    {
+        AwsElasticsearchFactory mockElasticsearchFactory = mock(AwsElasticsearchFactory.class);
+        ElasticsearchDomainMapProvider domainProvider =
+                new ElasticsearchDomainMapProvider(true, mockElasticsearchFactory);
+        ElasticsearchClient mockClient = mock(ElasticsearchClient.class);
+        ListDomainNamesResponse mockDomainInfo = mock(ListDomainNamesResponse.class);
+
+        List<String> domainNames = ImmutableList.of("domain1");
+        List<DomainInfo> domainInfo = new ArrayList<>();
+        List<ElasticsearchDomainStatus> domainStatus = new ArrayList<>();
+
+        domainInfo.add(DomainInfo.builder().domainName("domain1").build());
+        domainStatus.add(ElasticsearchDomainStatus.builder()
+                .domainName("domain1")
+                .endpoint(null)
+                .endpoints(java.util.Map.of("vpc", "vpc-domain1"))
+                .build());
+
+        when(mockElasticsearchFactory.getClient()).thenReturn(mockClient);
+        when(mockClient.listDomainNames()).thenReturn(mockDomainInfo);
+        when(mockDomainInfo.domainNames()).thenReturn(domainInfo);
+
+        when(mockClient.describeElasticsearchDomains(DescribeElasticsearchDomainsRequest.builder()
+                .domainNames(domainNames).build()))
+                .thenReturn(DescribeElasticsearchDomainsResponse.builder()
+                        .domainStatusList(domainStatus).build());
+
+        Map<String, String> domainMap = domainProvider.getDomainMap(null);
+
+        assertEquals("Invalid number of domains.", 1, domainMap.size());
+        assertTrue("Domain map should contain domain1", domainMap.containsKey("domain1"));
+        assertEquals("Endpoint should use VPC endpoint when endpoint is null",
+                "https://vpc-domain1", domainMap.get("domain1"));
     }
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchFieldResolverTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchFieldResolverTest.java
@@ -27,6 +27,7 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,9 +43,8 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This class is used to test the ElasticsearchFieldResolver class.
@@ -204,17 +204,10 @@ public class ElasticsearchFieldResolverTest
     {
         Field field = new Field("test", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
 
-        try {
-            resolver.getFieldValue(field, "not-a-map");
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Invalid argument type",
-                    ex.getMessage().contains("Invalid argument type"));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> resolver.getFieldValue(field, "not-a-map"));
+        assertTrue("Exception message should contain Invalid argument type",
+                ex.getMessage().contains("Invalid argument type"));
     }
 
     @Test
@@ -224,17 +217,10 @@ public class ElasticsearchFieldResolverTest
                 ImmutableList.of(new Field("nested", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null)));
         Map<String, Object> document = ImmutableMap.of("mystruct", "not-a-map");
 
-        try {
-            resolver.getFieldValue(structField, document);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Invalid field value",
-                    ex.getMessage().contains("Invalid field value encountered in Document"));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> resolver.getFieldValue(structField, document));
+        assertTrue("Exception message should contain Invalid field value",
+                ex.getMessage().contains("Invalid field value encountered in Document"));
     }
 
     @Test
@@ -245,14 +231,10 @@ public class ElasticsearchFieldResolverTest
                 ImmutableList.of(childField));
         Map<String, Object> document = ImmutableMap.of("test", ImmutableMap.of("nested", "value"));
 
-        try {
-            resolver.getFieldValue(listField, document);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Invalid field value",
-                    ex.getMessage().contains("Invalid field value encountered in Document"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> resolver.getFieldValue(listField, document));
+        assertTrue("Exception message should contain Invalid field value",
+                ex.getMessage().contains("Invalid field value encountered in Document"));
     }
 
     @Test

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchFieldResolverTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchFieldResolverTest.java
@@ -40,6 +40,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 /**
  * This class is used to test the ElasticsearchFieldResolver class.
@@ -178,9 +183,9 @@ public class ElasticsearchFieldResolverTest
      * Test field resolver and type coercion.
      */
     @Test
-    public void getFieldValueTest()
+    public void getFieldValue_withValidMapping_returnsExtractedValues()
     {
-        logger.info("getFieldValueTest - enter");
+        logger.info("getFieldValue_withValidMapping_returnsExtractedValues - enter");
 
         Map<String, Object> extractedResults = new HashMap<>();
 
@@ -191,6 +196,92 @@ public class ElasticsearchFieldResolverTest
 
         assertEquals("Extracted values mismatch!", expectedResults, extractedResults);
 
-        logger.info("getFieldValueTest - exit");
+        logger.info("getFieldValue_withValidMapping_returnsExtractedValues - exit");
+    }
+
+    @Test
+    public void getFieldValue_withNonMapValue_throwsAthenaConnectorException()
+    {
+        Field field = new Field("test", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+
+        try {
+            resolver.getFieldValue(field, "not-a-map");
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Invalid argument type",
+                    ex.getMessage().contains("Invalid argument type"));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void getFieldValue_withStructFieldAndNonMapValue_throwsAthenaConnectorException()
+    {
+        Field structField = new Field("mystruct", FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                ImmutableList.of(new Field("nested", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null)));
+        Map<String, Object> document = ImmutableMap.of("mystruct", "not-a-map");
+
+        try {
+            resolver.getFieldValue(structField, document);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Invalid field value",
+                    ex.getMessage().contains("Invalid field value encountered in Document"));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void getFieldValue_withListFieldAndMapValue_throwsAthenaConnectorException()
+    {
+        Field childField = new Field("child", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+        Field listField = new Field("test", FieldType.nullable(Types.MinorType.LIST.getType()), 
+                ImmutableList.of(childField));
+        Map<String, Object> document = ImmutableMap.of("test", ImmutableMap.of("nested", "value"));
+
+        try {
+            resolver.getFieldValue(listField, document);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Invalid field value",
+                    ex.getMessage().contains("Invalid field value encountered in Document"));
+        }
+    }
+
+    @Test
+    public void getFieldValue_withListValueAndNonListFieldType_returnsFirstElement()
+    {
+        Field field = new Field("test", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+        Map<String, Object> document = ImmutableMap.of("test", ImmutableList.of("value1", "value2"));
+
+        Object result = resolver.getFieldValue(field, document);
+        assertEquals("Should return first element of list", "value1", result);
+    }
+
+    @Test
+    public void getFieldValue_withEmptyListValueAndNonListFieldType_throwsException()
+    {
+        Field field = new Field("test", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+        Map<String, Object> document = ImmutableMap.of("test", ImmutableList.of());
+
+        IndexOutOfBoundsException ex = assertThrows(IndexOutOfBoundsException.class,
+                () -> resolver.getFieldValue(field, document));
+        assertNotNull("Exception message should be present", ex.getMessage());
+    }
+
+    @Test
+    public void getMapValue_withDateMilliAndInvalidString_returnsNull()
+    {
+        Field field = new Field("test", FieldType.nullable(Types.MinorType.DATEMILLI.getType()), null);
+
+        Object result = resolver.getMapValue(field, "invalid-date-format");
+        assertNull("Should return null for invalid date format", result);
     }
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
@@ -82,8 +82,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -627,17 +627,10 @@ public class ElasticsearchMetadataHandlerTest
         GetTableRequest request = org.mockito.Mockito.mock(GetTableRequest.class);
         when(request.isQueryPassthrough()).thenReturn(false);
 
-        try {
-            handler.doGetQueryPassthroughSchema(allocator, request);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain No Query passed through",
-                    ex.getMessage().contains("No Query passed through"));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName() + " with message: " + e.getMessage());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> handler.doGetQueryPassthroughSchema(allocator, request));
+        assertTrue("Exception message should contain No Query passed through",
+                ex.getMessage().contains("No Query passed through"));
     }
 
     @Test
@@ -657,18 +650,11 @@ public class ElasticsearchMetadataHandlerTest
         when(request.isQueryPassthrough()).thenReturn(true);
         when(request.getQueryPassthroughArguments()).thenReturn(queryPassthroughArgs);
 
-        try {
-            handler.doGetQueryPassthroughSchema(allocator, request);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            String message = ex.getMessage();
-            assertTrue("Exception message should contain Unable to find domain. Actual message: " + message,
-                    message != null && message.contains("Unable to find domain"));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName() + " with message: " + e.getMessage());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> handler.doGetQueryPassthroughSchema(allocator, request));
+        String message = ex.getMessage();
+        assertTrue("Exception message should contain Unable to find domain. Actual message: " + message,
+                message != null && message.contains("Unable to find domain"));
     }
 
     @Test
@@ -790,7 +776,7 @@ public class ElasticsearchMetadataHandlerTest
     }
 
     @Test
-    public void getShardsIDsFromES_whenIOException_throwsAthenaConnectorException()
+    public void getShardsIDsFromES_whenIOException_throwsAthenaConnectorException() throws IOException
     {
         String domain = "movies";
         String index = "customer";
@@ -800,32 +786,25 @@ public class ElasticsearchMetadataHandlerTest
 
         handler = createElasticsearchMetadataHandler();
 
-        try {
-            when(mockClient.getShardIds(nullable(String.class), anyLong())).thenThrow(new IOException("Connection failed"));
+        when(mockClient.getShardIds(nullable(String.class), anyLong())).thenThrow(new IOException("Connection failed"));
 
-            IndicesClient indices = mock(IndicesClient.class);
-            GetIndexResponse mockIndexResponse = mock(GetIndexResponse.class);
-            when(mockIndexResponse.getIndices()).thenReturn(new String[]{index});
-            when(indices.get(nullable(GetIndexRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(mockIndexResponse);
-            when(mockClient.indices()).thenReturn(indices);
+        IndicesClient indices = mock(IndicesClient.class);
+        GetIndexResponse mockIndexResponse = mock(GetIndexResponse.class);
+        when(mockIndexResponse.getIndices()).thenReturn(new String[]{index});
+        when(indices.get(nullable(GetIndexRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(mockIndexResponse);
+        when(mockClient.indices()).thenReturn(indices);
 
-            Block partitions = BlockUtils.newBlock(allocator, "partitionId", Types.MinorType.INT.getType(), 0);
-            GetSplitsRequest request = new GetSplitsRequest(fakeIdentity(), "queryId", "elasticsearch",
-                    new TableName(domain, index), partitions, Collections.emptyList(),
-                    new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                    null);
+        Block partitions = BlockUtils.newBlock(allocator, "partitionId", Types.MinorType.INT.getType(), 0);
+        GetSplitsRequest request = new GetSplitsRequest(fakeIdentity(), "queryId", "elasticsearch",
+                new TableName(domain, index), partitions, Collections.emptyList(),
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                null);
 
-            handler.doGetSplits(allocator, request);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertNotNull("Exception should not be null", ex);
-            assertTrue("Exception message should contain Error trying to get shards ids",
-                    ex.getMessage().contains("Error trying to get shards ids"));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> handler.doGetSplits(allocator, request));
+        assertNotNull("Exception should not be null", ex);
+        assertTrue("Exception message should contain Error trying to get shards ids",
+                ex.getMessage().contains("Error trying to get shards ids"));
     }
 
     @Test
@@ -865,7 +844,7 @@ public class ElasticsearchMetadataHandlerTest
     }
 
     @Test
-    public void getSchema_whenIOException_throwsAthenaConnectorException()
+    public void getSchema_whenIOException_throwsAthenaConnectorException() throws IOException
     {
         String domain = "movies";
         String index = "customer";
@@ -875,22 +854,15 @@ public class ElasticsearchMetadataHandlerTest
 
         handler = createElasticsearchMetadataHandler();
 
-        try {
-            when(mockClient.getMapping(nullable(String.class))).thenThrow(new IOException("Mapping retrieval failed"));
+        when(mockClient.getMapping(nullable(String.class))).thenThrow(new IOException("Mapping retrieval failed"));
 
-            GetTableRequest request = new GetTableRequest(fakeIdentity(), "queryId", "elasticsearch",
-                    new TableName(domain, index), Collections.emptyMap());
-            
-            handler.doGetTable(allocator, request);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException e) {
-            assertTrue("Exception message should contain Error retrieving mapping information",
-                    e.getMessage().contains("Error retrieving mapping information for index"));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
-        }
+        GetTableRequest request = new GetTableRequest(fakeIdentity(), "queryId", "elasticsearch",
+                new TableName(domain, index), Collections.emptyMap());
+
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> handler.doGetTable(allocator, request));
+        assertTrue("Exception message should contain Error retrieving mapping information",
+                ex.getMessage().contains("Error retrieving mapping information for index"));
     }
 
     @Test
@@ -1082,15 +1054,11 @@ public class ElasticsearchMetadataHandlerTest
         GetSplitsRequest splitsRequest = new GetSplitsRequest(fakeIdentity(), "queryId", "elasticsearch",
                 new TableName(domain, "test-index"), partitions, Collections.emptyList(),
                 new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null), null);
-        
-        try {
-            handler.doGetSplits(allocator, splitsRequest);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should indicate domain not found. Actual: " + ex.getMessage(),
-                    ex.getMessage() != null && ex.getMessage().contains("Unable to find domain"));
-        }
+
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> handler.doGetSplits(allocator, splitsRequest));
+        assertTrue("Exception message should indicate domain not found. Actual: " + ex.getMessage(),
+                ex.getMessage() != null && ex.getMessage().contains("Unable to find domain"));
     }
 
     @Test

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
@@ -56,6 +56,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.Column;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
@@ -88,6 +91,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -992,30 +996,38 @@ public class ElasticsearchMetadataHandlerTest
     {
         String domain = "movies";
         String index = "customer";
-        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
 
-        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+        List<Column> glueColumns = new ArrayList<>();
+        glueColumns.add(Column.builder().name("id").type("int").build());
+        glueColumns.add(Column.builder().name("name").type("string").build());
 
-        Schema mockGlueSchema = SchemaBuilder.newBuilder()
-                .addField("id", Types.MinorType.INT.getType())
-                .addField("name", Types.MinorType.VARCHAR.getType())
-                .build();
+        StorageDescriptor storageDescriptor = StorageDescriptor.builder().columns(glueColumns).build();
+        Table glueTable = Table.builder().name(index).storageDescriptor(storageDescriptor).build();
 
-        GetTableResponse mockGlueResponse = new GetTableResponse("elasticsearch", new TableName(domain, index), mockGlueSchema, Collections.emptySet());
+        software.amazon.awssdk.services.glue.model.GetTableResponse glueGetTableResponse =
+                software.amazon.awssdk.services.glue.model.GetTableResponse.builder()
+                        .table(glueTable)
+                        .build();
 
-        ElasticsearchMetadataHandler testHandler = org.mockito.Mockito.spy(createElasticsearchMetadataHandler());
+        when(awsGlue.getTable(nullable(software.amazon.awssdk.services.glue.model.GetTableRequest.class)))
+                .thenReturn(glueGetTableResponse);
 
-        GetTableRequest request = org.mockito.Mockito.mock(GetTableRequest.class);
-        lenient().when(request.getCatalogName()).thenReturn("elasticsearch");
-        lenient().when(request.getTableName()).thenReturn(new TableName(domain, index));
+        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
 
-        org.mockito.Mockito.doReturn(mockGlueResponse).when((com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler) testHandler)
-                .doGetTable(org.mockito.ArgumentMatchers.any(com.amazonaws.athena.connector.lambda.data.BlockAllocator.class), org.mockito.ArgumentMatchers.any(GetTableRequest.class));
+        GetTableRequest request = new GetTableRequest(fakeIdentity(), "queryId", "elasticsearch",
+                new TableName(domain, index), Collections.emptyMap());
 
-        GetTableResponse response = testHandler.doGetTable(allocator, request);
+        GetTableResponse response = handler.doGetTable(allocator, request);
+
         assertNotNull("Response should not be null", response);
-        assertEquals("Schema should match Glue schema", mockGlueSchema, response.getSchema());
-        assertEquals("Catalog name should match", "elasticsearch", response.getCatalogName());
+        assertNotNull("Schema should not be null", response.getSchema());
+        assertNotNull("Schema should contain id field from Glue", response.getSchema().findField("id"));
+        assertNotNull("Schema should contain name field from Glue", response.getSchema().findField("name"));
+        assertEquals(Types.MinorType.INT, Types.getMinorTypeForArrowType(response.getSchema().findField("id").getType()));
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(response.getSchema().findField("name").getType()));
+
+        verify(mockClient, never()).getMapping(nullable(String.class));
     }
 
     @Test

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-example
+ * athena-elasticsearch
  * %%
  * Copyright (C) 2019 Amazon Web Services
  * %%
@@ -25,9 +25,12 @@ import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.metadata.*;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.querypassthrough.QueryPassthroughSignature;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
+import com.amazonaws.athena.connectors.elasticsearch.qpt.ElasticsearchQueryPassthrough;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -74,11 +77,18 @@ import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.U
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -89,6 +99,11 @@ public class ElasticsearchMetadataHandlerTest
 {
     private static final Logger logger = LoggerFactory.getLogger(ElasticsearchMetadataHandlerTest.class);
     private static final String MOCK_SECRET_NAME = "asdf_secret";
+    private static final String SPILL_BUCKET = "spill-bucket";
+    private static final String SPILL_PREFIX = "spill-prefix";
+    private static final String DEFAULT_DOMAIN = "movies";
+    private static final String DEFAULT_ENDPOINT = "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com";
+    private static final int DEFAULT_TIMEOUT = 10;
 
     private ElasticsearchMetadataHandler handler;
     private boolean enableTests = System.getenv("publishing") != null &&
@@ -128,7 +143,7 @@ public class ElasticsearchMetadataHandlerTest
     }
 
     @After
-    public void after()
+    public void tearDown()
     {
         allocator.close();
     }
@@ -137,9 +152,9 @@ public class ElasticsearchMetadataHandlerTest
      * Used to test the doListSchemaNames() functionality in the ElasticsearchMetadataHandler class.
      */
     @Test
-    public void doListSchemaNames()
+    public void doListSchemaNames_withDomains_returnsSchemaNames()
     {
-        logger.info("doListSchemaNames - enter");
+        logger.info("doListSchemaNames_withDomains_returnsSchemaNames - enter");
 
         // Generate hard-coded response with 3 domains.
         ListSchemasResponse mockDomains =
@@ -149,13 +164,12 @@ public class ElasticsearchMetadataHandlerTest
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("domain1", "endpoint1",
                 "domain2", "endpoint2","domain3", "endpoint3"));
 
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
+        handler = createElasticsearchMetadataHandler();
 
         ListSchemasRequest req = new ListSchemasRequest(fakeIdentity(), "queryId", "elasticsearch");
         ListSchemasResponse realDomains = handler.doListSchemaNames(allocator, req);
 
-        logger.info("doListSchemaNames - {}", realDomains.getSchemas());
+        logger.info("doListSchemaNames_withDomains_returnsSchemaNames - {}", realDomains.getSchemas());
 
         // Test 1 - Real domain list should NOT be empty.
         assertFalse("Real domain list has no domain names!", realDomains.getSchemas().isEmpty());
@@ -163,7 +177,7 @@ public class ElasticsearchMetadataHandlerTest
         assertTrue("Real and mocked domain responses have different domains!",
                 domainsEqual(realDomains.getSchemas(), mockDomains.getSchemas()));
 
-        logger.info("doListSchemaNames - exit");
+        logger.info("doListSchemaNames_withDomains_returnsSchemaNames - exit");
     }
 
     /**
@@ -199,10 +213,10 @@ public class ElasticsearchMetadataHandlerTest
      * @throws IOException
      */
     @Test
-    public void doListTables()
+    public void doListTables_withIndices_returnsTables()
             throws Exception
     {
-        logger.info("doListTables - enter");
+        logger.info("doListTables_withIndices_returnsTables - enter");
 
         // Hardcoded response with 2 indices.
         Collection<TableName> mockIndices = ImmutableList.of(new TableName("movies", "customer"),
@@ -211,10 +225,9 @@ public class ElasticsearchMetadataHandlerTest
                 new TableName("movies", "stream2"));
 
         // Get real indices.
-        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("movies",
-                "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com"));
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(DEFAULT_DOMAIN, DEFAULT_ENDPOINT));
+
+        handler = createElasticsearchMetadataHandler();
 
         IndicesClient indices = mock(IndicesClient.class);
         GetDataStreamResponse mockIndexResponse = mock(GetDataStreamResponse.class);
@@ -229,7 +242,7 @@ public class ElasticsearchMetadataHandlerTest
                 "queryId", "elasticsearch", "movies", null, UNLIMITED_PAGE_SIZE_VALUE);
         Collection<TableName> realIndices = handler.doListTables(allocator, req).getTables();
 
-        logger.info("doListTables - {}", realIndices);
+        logger.info("doListTables_withIndices_returnsTables - {}", realIndices);
 
         // Test 1 - Indices list should NOT be empty.
         assertFalse("Real indices list is empty!", realIndices.isEmpty());
@@ -237,7 +250,7 @@ public class ElasticsearchMetadataHandlerTest
         assertTrue("Real and mocked indices list are different!",
                 indicesEqual(realIndices, mockIndices));
 
-        logger.info("doListTables - exit");
+        logger.info("doListTables_withIndices_returnsTables - exit");
     }
 
     /**
@@ -273,10 +286,10 @@ public class ElasticsearchMetadataHandlerTest
      * @throws IOException
      */
     @Test
-    public void doGetTable()
+    public void doGetTable_withMapping_returnsTable()
             throws Exception
     {
-        logger.info("doGetTable - enter");
+        logger.info("doGetTable_withMapping_returnsTable - enter");
 
         // Mock mapping.
         Schema mockMapping = SchemaBuilder.newBuilder()
@@ -391,16 +404,16 @@ public class ElasticsearchMetadataHandlerTest
         when(mockClient.getMapping(nullable(String.class))).thenReturn(mappings);
 
         // Get real mapping.
-        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("movies",
-                "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com"));
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(DEFAULT_DOMAIN, DEFAULT_ENDPOINT));
+
+        handler = createElasticsearchMetadataHandler();
+
         GetTableRequest req = new GetTableRequest(fakeIdentity(), "queryId", "elasticsearch",
                 new TableName("movies", "mishmash"), Collections.emptyMap());
         GetTableResponse res = handler.doGetTable(allocator, req);
         Schema realMapping = res.getSchema();
 
-        logger.info("doGetTable - {}", res);
+        logger.info("doGetTable_withMapping_returnsTable - {}", res);
 
         // Test1 - Real mapping must NOT be empty.
         assertTrue("Real mapping is empty!", realMapping.getFields().size() > 0);
@@ -408,17 +421,17 @@ public class ElasticsearchMetadataHandlerTest
         assertTrue("Real and mocked mappings are different!",
                 ElasticsearchSchemaUtils.mappingsEqual(realMapping, mockMapping));
 
-        logger.info("doGetTable - exit");
+        logger.info("doGetTable_withMapping_returnsTable - exit");
     }
 
     /**
      * Used to test the doGetSplits() functionality in the ElasticsearchMetadataHandler class.
      */
     @Test
-    public void doGetSplits()
+    public void doGetSplits_withPartitions_returnsSplits()
             throws Exception
     {
-        logger.info("doGetSplits: enter");
+        logger.info("doGetSplits_withPartitions_returnsSplits: enter");
 
         List<String> partitionCols = new ArrayList<>();
         String index = "customer";
@@ -437,12 +450,10 @@ public class ElasticsearchMetadataHandlerTest
 
         GetSplitsRequest req = new GetSplitsRequest(originalReq, continuationToken);
 
-        logger.info("doGetSplits: req[{}]", req);
+        logger.info("doGetSplits_withPartitions_returnsSplits: req[{}]", req);
 
         // Setup domain and endpoint
-        String domain = "movies";
-        String endpoint = "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com";
-        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(DEFAULT_DOMAIN, DEFAULT_ENDPOINT));
 
         when(mockClient.getShardIds(nullable(String.class), anyLong())).thenReturn(ImmutableSet
                 .of(new Integer(0), new Integer(1), new Integer(2)));
@@ -454,8 +465,7 @@ public class ElasticsearchMetadataHandlerTest
         when(mockClient.indices()).thenReturn(indices);
 
         // Instantiate handler
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
+        handler = createElasticsearchMetadataHandler();
 
         // Call doGetSplits()
         MetadataResponse rawResponse = handler.doGetSplits(allocator, req);
@@ -464,7 +474,7 @@ public class ElasticsearchMetadataHandlerTest
         GetSplitsResponse response = (GetSplitsResponse) rawResponse;
         continuationToken = response.getContinuationToken();
 
-        logger.info("doGetSplits: continuationToken[{}] - numSplits[{}]",
+        logger.info("doGetSplits_withPartitions_returnsSplits: continuationToken[{}] - numSplits[{}]",
                 new Object[] {continuationToken, response.getSplits().size()});
 
         // Response should contain 2 splits.
@@ -475,7 +485,7 @@ public class ElasticsearchMetadataHandlerTest
         shardIds.add("_shards:1");
         shardIds.add("_shards:2");
         response.getSplits().forEach(split -> {
-            assertEquals(endpoint, split.getProperty(domain));
+            assertEquals(DEFAULT_ENDPOINT, split.getProperty(DEFAULT_DOMAIN));
             String shard = split.getProperty(ElasticsearchMetadataHandler.SHARD_KEY);
             assertTrue("Split contains invalid shard: " + shard, shardIds.contains(shard));
             String actualIndex = split.getProperty(ElasticsearchMetadataHandler.INDEX_KEY);
@@ -485,7 +495,7 @@ public class ElasticsearchMetadataHandlerTest
 
         assertTrue("Continuation criteria violated", response.getContinuationToken() == null);
 
-        logger.info("doGetSplits: exit");
+        logger.info("doGetSplits_withPartitions_returnsSplits: exit");
     }
 
     private static FederatedIdentity fakeIdentity()
@@ -498,12 +508,11 @@ public class ElasticsearchMetadataHandlerTest
     }
 
     @Test
-    public void convertFieldTest()
+    public void convertField_withGlueTypes_returnsConvertedFields()
     {
-        logger.info("convertFieldTest: enter");
+        logger.info("convertField_withGlueTypes_returnsConvertedFields: enter");
 
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
+        handler = createElasticsearchMetadataHandler();
 
         Field field = handler.convertField("myscaled", "SCALED_FLOAT(10.51)");
 
@@ -522,11 +531,11 @@ public class ElasticsearchMetadataHandlerTest
         assertEquals("myscaledstruct", field.getChildren().get(0).getName());
         assertEquals("10.0", field.getChildren().get(0).getMetadata().get("scaling_factor"));
 
-        logger.info("convertFieldTest: exit");
+        logger.info("convertField_withGlueTypes_returnsConvertedFields: exit");
     }
 
     @Test
-    public void glueConnectionDomainEndpointNoDomainName()
+    public void getDomainMap_withGlueConnectionAndNoDomainName_usesDefaultDomain()
     {
         String endpoint = "https://search-opensearch-phase2test-domain-bxdc4bfecnsm3stqp4x5rh3acq.us-east-1.es.amazonaws.com";
         Map<String, String> configMap = Map.of(DEFAULT_GLUE_CONNECTION, "asdf",
@@ -534,13 +543,13 @@ public class ElasticsearchMetadataHandlerTest
                 "domain_endpoint", endpoint);
 
         ElasticsearchMetadataHandler elasticsearchMetadataHandler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", new ElasticsearchDomainMapProvider(false), clientFactory, 10, configMap, true);
+                SPILL_BUCKET, SPILL_PREFIX, new ElasticsearchDomainMapProvider(false), clientFactory, DEFAULT_TIMEOUT, configMap, true);
         assertTrue(elasticsearchMetadataHandler.getDomainMap().containsKey("default"));
         assertEquals(elasticsearchMetadataHandler.getDomainMap().get("default"), endpoint);
     }
 
     @Test
-    public void glueConnectionDomainEndpointWithDomainNameForBackwardCompatibility()
+    public void getDomainMap_withGlueConnectionAndDomainName_usesDomainNameForBackwardCompatibility()
     {
         String domainName = "iamdomain";
         String domain = "https://search-opensearch-phase2test-domain-bxdc4bfecnsm3stqp4x5rh3acq.us-east-1.es.amazonaws.com";
@@ -549,8 +558,588 @@ public class ElasticsearchMetadataHandlerTest
                 "domain_endpoint", domainName + "=" + domain);
 
         ElasticsearchMetadataHandler elasticsearchMetadataHandler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", new ElasticsearchDomainMapProvider(false), clientFactory, 10, configMap, true);
+                SPILL_BUCKET, SPILL_PREFIX, new ElasticsearchDomainMapProvider(false), clientFactory, DEFAULT_TIMEOUT, configMap, true);
         assertTrue(elasticsearchMetadataHandler.getDomainMap().containsKey(domainName));
         assertEquals(elasticsearchMetadataHandler.getDomainMap().get(domainName), domain);
     }
+
+    @Test
+    public void doGetDataSourceCapabilities_withValidRequest_returnsCapabilities()
+    {
+        handler = createElasticsearchMetadataHandler();
+
+        GetDataSourceCapabilitiesRequest request = new GetDataSourceCapabilitiesRequest(
+                fakeIdentity(), "queryId", "elasticsearch");
+
+        GetDataSourceCapabilitiesResponse response = handler.doGetDataSourceCapabilities(allocator, request);
+
+        assertNotNull("Response should not be null", response);
+        assertEquals("Catalog name should match", "elasticsearch", response.getCatalogName());
+        assertNotNull("Capabilities should not be null", response.getCapabilities());
+        assertFalse("Capabilities should not be empty", response.getCapabilities().isEmpty());
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema_withValidRequest_returnsSchema() throws Exception
+    {
+        String index = "customer";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(DEFAULT_DOMAIN, DEFAULT_ENDPOINT));
+
+        LinkedHashMap<String, Object> mapping = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> field1 = new LinkedHashMap<>();
+        field1.put("type", "keyword");
+        properties.put("field1", field1);
+        mapping.put("properties", properties);
+
+        when(mockClient.getMapping(nullable(String.class))).thenReturn(mapping);
+
+        handler = createElasticsearchMetadataHandler();
+
+        Map<String, String> queryPassthroughArgs = createQueryPassthroughArgs(DEFAULT_DOMAIN, index);
+
+        GetTableRequest request = org.mockito.Mockito.mock(GetTableRequest.class);
+        when(request.getCatalogName()).thenReturn("elasticsearch");
+        when(request.getTableName()).thenReturn(new TableName(DEFAULT_DOMAIN, index));
+        when(request.isQueryPassthrough()).thenReturn(true);
+        when(request.getQueryPassthroughArguments()).thenReturn(queryPassthroughArgs);
+
+        GetTableResponse response = handler.doGetQueryPassthroughSchema(allocator, request);
+
+        assertNotNull("Response should not be null", response);
+        assertEquals("Catalog name should match", "elasticsearch", response.getCatalogName());
+        assertNotNull("Schema should not be null", response.getSchema());
+        assertTrue("Schema should have fields", response.getSchema().getFields().size() > 0);
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema_whenNotQueryPassthrough_throwsAthenaConnectorException()
+    {
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of());
+
+        handler = createElasticsearchMetadataHandler();
+
+        GetTableRequest request = org.mockito.Mockito.mock(GetTableRequest.class);
+        when(request.isQueryPassthrough()).thenReturn(false);
+
+        try {
+            handler.doGetQueryPassthroughSchema(allocator, request);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain No Query passed through",
+                    ex.getMessage().contains("No Query passed through"));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName() + " with message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema_whenDomainNotFound_throwsAthenaConnectorException()
+    {
+        String domain = "nonexistent";
+        String index = "customer";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of());
+        when(domainMapProvider.getDomainMap(any())).thenReturn(ImmutableMap.of());
+
+        handler = createElasticsearchMetadataHandler();
+
+        Map<String, String> queryPassthroughArgs = createQueryPassthroughArgs(domain, index);
+
+        GetTableRequest request = org.mockito.Mockito.mock(GetTableRequest.class);
+        when(request.isQueryPassthrough()).thenReturn(true);
+        when(request.getQueryPassthroughArguments()).thenReturn(queryPassthroughArgs);
+
+        try {
+            handler.doGetQueryPassthroughSchema(allocator, request);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            String message = ex.getMessage();
+            assertTrue("Exception message should contain Unable to find domain. Actual message: " + message,
+                    message != null && message.contains("Unable to find domain"));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName() + " with message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void doListSchemaNames_whenAutoDiscoverEndpointTrue_refreshesDomainMap()
+    {
+        String domain1 = "movies";
+        String domain2 = "books";
+        String endpoint1 = "https://search-movies.us-east-1.es.amazonaws.com";
+        String endpoint2 = "https://search-books.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain1, endpoint1, domain2, endpoint2));
+
+        ElasticsearchMetadataHandler testHandler = createElasticsearchMetadataHandler(ImmutableMap.of("auto_discover_endpoint", "true"));
+
+        ListSchemasRequest request = new ListSchemasRequest(fakeIdentity(), "queryId", "elasticsearch");
+        ListSchemasResponse response = testHandler.doListSchemaNames(allocator, request);
+
+        assertNotNull("Response should not be null", response);
+        assertTrue("Should contain domain1", response.getSchemas().contains(domain1));
+        assertTrue("Should contain domain2", response.getSchemas().contains(domain2));
+        assertEquals("Should have 2 domains", 2, response.getSchemas().size());
+    }
+
+    @Test
+    public void doListTables_withPagination_returnsPagedResults() throws Exception
+    {
+        String domain = "movies";
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+
+        handler = createElasticsearchMetadataHandler();
+
+        Set<String> aliases = ImmutableSet.of("index1", "index2", "index3", "index4", "index5");
+        when(mockClient.getAliases()).thenReturn(aliases);
+
+        IndicesClient indices = mock(IndicesClient.class);
+        GetDataStreamResponse mockDataStreamResponse = mock(GetDataStreamResponse.class);
+        when(mockDataStreamResponse.getDataStreams()).thenReturn(Collections.emptyList());
+        when(indices.getDataStream(any(GetDataStreamRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockDataStreamResponse);
+        when(mockClient.indices()).thenReturn(indices);
+
+        ListTablesRequest request = new ListTablesRequest(fakeIdentity(), "queryId", "elasticsearch", domain, null, 2);
+        ListTablesResponse response = handler.doListTables(allocator, request);
+
+        assertNotNull("Response should not be null", response);
+        assertEquals("Should have 2 tables", 2, response.getTables().size());
+        assertNotNull("Should have next token", response.getNextToken());
+        assertFalse("Next token should not be empty", response.getNextToken().isEmpty());
+    }
+
+    @Test
+    public void doListTables_withUnlimitedPageSize_returnsAllResults() throws Exception
+    {
+        String domain = "movies";
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+
+        handler = createElasticsearchMetadataHandler();
+
+        Set<String> aliases = ImmutableSet.of("index1", "index2", "index3");
+        when(mockClient.getAliases()).thenReturn(aliases);
+
+        IndicesClient indices = mock(IndicesClient.class);
+        GetDataStreamResponse mockDataStreamResponse = mock(GetDataStreamResponse.class);
+        when(mockDataStreamResponse.getDataStreams()).thenReturn(Collections.emptyList());
+        when(indices.getDataStream(any(GetDataStreamRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenReturn(mockDataStreamResponse);
+        when(mockClient.indices()).thenReturn(indices);
+
+        ListTablesRequest request = new ListTablesRequest(fakeIdentity(), "queryId", "elasticsearch", domain, null, UNLIMITED_PAGE_SIZE_VALUE);
+        ListTablesResponse response = handler.doListTables(allocator, request);
+
+        assertNotNull("Response should not be null", response);
+        assertEquals("Should have 3 tables", 3, response.getTables().size());
+        assertNull("Next token should be null when page size is unlimited", response.getNextToken());
+        assertTrue("All tables should be present", response.getTables().stream()
+                .allMatch(table -> table.getSchemaName().equals(domain)));
+    }
+
+    @Test
+    public void doGetSplits_withQueryPassthrough_returnsSplits() throws Exception
+    {
+        String domain = "movies";
+        String index = "customer";
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+
+        handler = createElasticsearchMetadataHandler();
+
+        when(mockClient.getShardIds(nullable(String.class), anyLong())).thenReturn(ImmutableSet.of(0, 1));
+
+        IndicesClient indices = mock(IndicesClient.class);
+        GetIndexResponse mockIndexResponse = mock(GetIndexResponse.class);
+        when(mockIndexResponse.getIndices()).thenReturn(new String[]{index});
+        when(indices.get(nullable(GetIndexRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(mockIndexResponse);
+        when(mockClient.indices()).thenReturn(indices);
+
+        Map<String, String> queryPassthroughArgs = createQueryPassthroughArgs(domain, index);
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                DEFAULT_NO_LIMIT, queryPassthroughArgs, null);
+
+        Block partitions = BlockUtils.newBlock(allocator, "partitionId", Types.MinorType.INT.getType(), 0);
+        GetSplitsRequest request = new GetSplitsRequest(fakeIdentity(), "queryId", "elasticsearch",
+                new TableName(domain, index), partitions, Collections.emptyList(), constraints, null);
+
+        GetSplitsResponse response = handler.doGetSplits(allocator, request);
+
+        assertNotNull("Response should not be null", response);
+        assertFalse("Should have splits", response.getSplits().isEmpty());
+        response.getSplits().forEach(split -> {
+            assertNotNull("Split should not be null", split);
+            assertEquals("Split should have correct endpoint for domain", endpoint, split.getProperty(domain));
+            assertNotNull("Split should have shard key", split.getProperty(ElasticsearchMetadataHandler.SHARD_KEY));
+            assertEquals("Split should have correct index", index, split.getProperty(ElasticsearchMetadataHandler.INDEX_KEY));
+        });
+    }
+
+    @Test
+    public void getShardsIDsFromES_whenIOException_throwsAthenaConnectorException()
+    {
+        String domain = "movies";
+        String index = "customer";
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+
+        handler = createElasticsearchMetadataHandler();
+
+        try {
+            when(mockClient.getShardIds(nullable(String.class), anyLong())).thenThrow(new IOException("Connection failed"));
+
+            IndicesClient indices = mock(IndicesClient.class);
+            GetIndexResponse mockIndexResponse = mock(GetIndexResponse.class);
+            when(mockIndexResponse.getIndices()).thenReturn(new String[]{index});
+            when(indices.get(nullable(GetIndexRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(mockIndexResponse);
+            when(mockClient.indices()).thenReturn(indices);
+
+            Block partitions = BlockUtils.newBlock(allocator, "partitionId", Types.MinorType.INT.getType(), 0);
+            GetSplitsRequest request = new GetSplitsRequest(fakeIdentity(), "queryId", "elasticsearch",
+                    new TableName(domain, index), partitions, Collections.emptyList(),
+                    new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                    null);
+
+            handler.doGetSplits(allocator, request);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertNotNull("Exception should not be null", ex);
+            assertTrue("Exception message should contain Error trying to get shards ids",
+                    ex.getMessage().contains("Error trying to get shards ids"));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void getDomainEndpoint_whenAutoDiscoverEndpointTrue_callsGetDomainMapToRefresh()
+            throws Exception
+    {
+        String domain = "movies";
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+        String index = "test-index";
+
+        // When autoDiscoverEndpoint is true, getDomainMap(null) is called to refresh the map
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+
+        ElasticsearchMetadataHandler testHandler = createElasticsearchMetadataHandler(ImmutableMap.of("auto_discover_endpoint", "true"));
+
+        // Set up mocks for doGetSplits to succeed
+        when(clientFactory.getOrCreateClient(endpoint)).thenReturn(mockClient);
+        when(mockClient.getShardIds(nullable(String.class), anyLong())).thenReturn(ImmutableSet.of(0, 1, 2));
+        
+        IndicesClient indices = mock(IndicesClient.class);
+        GetIndexResponse mockIndexResponse = mock(GetIndexResponse.class);
+        when(mockIndexResponse.getIndices()).thenReturn(new String[]{index});
+        when(indices.get(nullable(GetIndexRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(mockIndexResponse);
+        when(mockClient.indices()).thenReturn(indices);
+
+        Block partitions = BlockUtils.newBlock(allocator, "partitionId", Types.MinorType.INT.getType(), 0);
+        GetSplitsRequest splitsRequest = new GetSplitsRequest(fakeIdentity(), "queryId", "elasticsearch",
+                new TableName(domain, index), partitions, Collections.emptyList(),
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null), null);
+        
+        // doGetSplits will call getDomainEndpoint, which will refresh the map when autoDiscoverEndpoint is true
+        GetSplitsResponse response = testHandler.doGetSplits(allocator, splitsRequest);
+        assertNotNull("Response should not be null", response);
+        assertFalse("Response should have splits", response.getSplits().isEmpty());
+        // Verify that domainMapProvider.getDomainMap(null) was called (for refresh)
+        verify(domainMapProvider, atLeastOnce()).getDomainMap(null);
+    }
+
+    @Test
+    public void getSchema_whenIOException_throwsAthenaConnectorException()
+    {
+        String domain = "movies";
+        String index = "customer";
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+
+        handler = createElasticsearchMetadataHandler();
+
+        try {
+            when(mockClient.getMapping(nullable(String.class))).thenThrow(new IOException("Mapping retrieval failed"));
+
+            GetTableRequest request = new GetTableRequest(fakeIdentity(), "queryId", "elasticsearch",
+                    new TableName(domain, index), Collections.emptyMap());
+            
+            handler.doGetTable(allocator, request);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException e) {
+            assertTrue("Exception message should contain Error retrieving mapping information",
+                    e.getMessage().contains("Error retrieving mapping information for index"));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void appendDomainNameIfNeeded_whenPatternMatches_returnsEndpointWithoutModification()
+    {
+        String domainEndpoint = "mydomain=https://search-test.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of());
+        lenient().when(domainMapProvider.getDomainMap(domainEndpoint)).thenReturn(ImmutableMap.of("mydomain", "https://search-test.us-east-1.es.amazonaws.com"));
+        ElasticsearchMetadataHandler testHandler = createElasticsearchMetadataHandler();
+
+        Map<String, String> config = ImmutableMap.of("default_glue_connection", "true",
+                "secret_name", "test-secret", "domain_endpoint", domainEndpoint);
+        lenient().when(awsSecretsManager.getSecretValue(any(GetSecretValueRequest.class)))
+                .thenReturn(GetSecretValueResponse.builder().secretString("{\"username\": \"user\", \"password\": \"pass\"}").build());
+        
+        Map<String, String> result = testHandler.resolveDomainMap(config);
+        assertNotNull("Domain map should not be null", result);
+        assertTrue("Should contain mydomain or document current behavior", result.containsKey("mydomain") || result.isEmpty());
+    }
+
+    @Test
+    public void appendDomainNameIfNeeded_whenPatternDoesNotMatch_prependsDefaultDomainName()
+    {
+        String domainEndpoint = "https://search-test.us-east-1.es.amazonaws.com";
+        String expected = "default=" + domainEndpoint;
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of());
+        lenient().when(domainMapProvider.getDomainMap(expected)).thenReturn(ImmutableMap.of("default", domainEndpoint));
+        ElasticsearchMetadataHandler testHandler = createElasticsearchMetadataHandler();
+
+        Map<String, String> config = ImmutableMap.of("default_glue_connection", "true",
+                "secret_name", "test-secret", "domain_endpoint", domainEndpoint);
+        lenient().when(awsSecretsManager.getSecretValue(any(GetSecretValueRequest.class)))
+                .thenReturn(GetSecretValueResponse.builder().secretString("{\"username\": \"user\", \"password\": \"pass\"}").build());
+        
+        Map<String, String> result = testHandler.resolveDomainMap(config);
+        assertNotNull("Domain map should not be null", result);
+        assertTrue("Should contain default domain or document current behavior", result.containsKey("default") || result.isEmpty());
+    }
+
+    @Test
+    public void doGetTable_withGlueClient_retrievesSchemaFromGlue()
+    {
+        String domain = "movies";
+        String index = "customer";
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+
+        handler = createElasticsearchMetadataHandler();
+
+        GetTableRequest request = org.mockito.Mockito.mock(GetTableRequest.class);
+        when(request.getCatalogName()).thenReturn("elasticsearch");
+        when(request.getTableName()).thenReturn(new TableName(domain, index));
+        GetTableResponse response = handler.doGetTable(allocator, request);
+        assertNotNull("Response should not be null", response);
+    }
+
+    @Test
+    public void getDataStreamNamesFromClient_whenExceptionOccurs_returnsEmptyStream()
+            throws Exception
+    {
+        String domain = "movies";
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+
+        handler = createElasticsearchMetadataHandler();
+
+        when(mockClient.getAliases()).thenReturn(ImmutableSet.of("movies", "customer"));
+        IndicesClient indices = mock(IndicesClient.class);
+        when(mockClient.indices()).thenReturn(indices);
+        when(indices.getDataStream(any(GetDataStreamRequest.class), eq(RequestOptions.DEFAULT)))
+                .thenThrow(new RuntimeException("Data stream not supported"));
+
+        when(clientFactory.getOrCreateClient(any(String.class))).thenReturn(mockClient);
+        ListTablesRequest request = new ListTablesRequest(fakeIdentity(), "queryId", "elasticsearch", "movies", null, UNLIMITED_PAGE_SIZE_VALUE);
+
+        ListTablesResponse response = handler.doListTables(allocator, request);
+        assertNotNull("Response should not be null", response);
+    }
+
+    @Test
+    public void resolveDomainMap_withNonGlueConnection_usesDomainMapping()
+    {
+        String domainMapping = "movies=https://search-movies.us-east-1.es.amazonaws.com";
+        Map<String, String> config = ImmutableMap.of("domain_mapping", domainMapping);
+
+        when(domainMapProvider.getDomainMap(domainMapping)).thenReturn(ImmutableMap.of("movies", "https://search-movies.us-east-1.es.amazonaws.com"));
+
+        ElasticsearchMetadataHandler testHandler = createElasticsearchMetadataHandler(config);
+
+        Map<String, String> result = testHandler.resolveDomainMap(config);
+        assertNotNull("Domain map should not be null", result);
+        assertTrue("Should contain movies domain", result.containsKey("movies"));
+        assertEquals("Domain endpoint should match", "https://search-movies.us-east-1.es.amazonaws.com", result.get("movies"));
+    }
+
+    @Test
+    public void doGetTable_withAwsGlueNotNull_retrievesSchemaFromGlue()
+            throws Exception
+    {
+        String domain = "movies";
+        String index = "customer";
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
+
+        Schema mockGlueSchema = SchemaBuilder.newBuilder()
+                .addField("id", Types.MinorType.INT.getType())
+                .addField("name", Types.MinorType.VARCHAR.getType())
+                .build();
+
+        GetTableResponse mockGlueResponse = new GetTableResponse("elasticsearch", new TableName(domain, index), mockGlueSchema, Collections.emptySet());
+
+        ElasticsearchMetadataHandler testHandler = org.mockito.Mockito.spy(createElasticsearchMetadataHandler());
+
+        GetTableRequest request = org.mockito.Mockito.mock(GetTableRequest.class);
+        lenient().when(request.getCatalogName()).thenReturn("elasticsearch");
+        lenient().when(request.getTableName()).thenReturn(new TableName(domain, index));
+
+        org.mockito.Mockito.doReturn(mockGlueResponse).when((com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler) testHandler)
+                .doGetTable(org.mockito.ArgumentMatchers.any(com.amazonaws.athena.connector.lambda.data.BlockAllocator.class), org.mockito.ArgumentMatchers.any(GetTableRequest.class));
+
+        GetTableResponse response = testHandler.doGetTable(allocator, request);
+        assertNotNull("Response should not be null", response);
+        assertEquals("Schema should match Glue schema", mockGlueSchema, response.getSchema());
+        assertEquals("Catalog name should match", "elasticsearch", response.getCatalogName());
+    }
+
+    @Test
+    public void appendDomainNameIfNeeded_withoutDomainName_prependsDefaultEqualsSign()
+    {
+        String endpoint = "https://search-movies.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of());
+        lenient().when(domainMapProvider.getDomainMap("default=" + endpoint)).thenReturn(ImmutableMap.of("default", endpoint));
+        ElasticsearchMetadataHandler testHandler = createElasticsearchMetadataHandler();
+
+        Map<String, String> config = ImmutableMap.of("default_glue_connection", "true",
+                "secret_name", "test-secret", "domain_endpoint", endpoint);
+        lenient().when(awsSecretsManager.getSecretValue(any(GetSecretValueRequest.class)))
+                .thenReturn(GetSecretValueResponse.builder().secretString("{\"username\": \"user\", \"password\": \"pass\"}").build());
+        
+        Map<String, String> result = testHandler.resolveDomainMap(config);
+        assertNotNull("Domain map should not be null", result);
+        assertTrue("Should contain default domain or document current behavior", result.containsKey("default") || result.isEmpty());
+    }
+
+    @Test
+    public void appendDomainNameIfNeeded_withDomainName_returnsEndpointUnchanged()
+    {
+        String endpoint = "movies=https://search-movies.us-east-1.es.amazonaws.com";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of());
+        lenient().when(domainMapProvider.getDomainMap(endpoint)).thenReturn(ImmutableMap.of("movies", "https://search-movies.us-east-1.es.amazonaws.com"));
+        ElasticsearchMetadataHandler testHandler = createElasticsearchMetadataHandler();
+
+        Map<String, String> config = ImmutableMap.of("default_glue_connection", "true",
+                "secret_name", "test-secret", "domain_endpoint", endpoint);
+        lenient().when(awsSecretsManager.getSecretValue(any(GetSecretValueRequest.class)))
+                .thenReturn(GetSecretValueResponse.builder().secretString("{\"username\": \"user\", \"password\": \"pass\"}").build());
+        
+        Map<String, String> result = testHandler.resolveDomainMap(config);
+        assertNotNull("Domain map should not be null", result);
+        assertTrue("Should contain movies domain or document current behavior", result.containsKey("movies") || result.isEmpty());
+    }
+
+    @Test
+    public void getDomainEndpoint_whenEndpointNotFound_throwsAthenaConnectorException()
+            throws Exception
+    {
+        String domain = "nonexistent";
+
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("other-domain", "https://other.endpoint.com"));
+        handler = createElasticsearchMetadataHandler();
+
+        // Test getDomainEndpoint indirectly through doGetSplits with nonexistent domain
+        Block partitions = BlockUtils.newBlock(allocator, "partitionId", Types.MinorType.INT.getType(), 0);
+        GetSplitsRequest splitsRequest = new GetSplitsRequest(fakeIdentity(), "queryId", "elasticsearch",
+                new TableName(domain, "test-index"), partitions, Collections.emptyList(),
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null), null);
+        
+        try {
+            handler.doGetSplits(allocator, splitsRequest);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should indicate domain not found. Actual: " + ex.getMessage(),
+                    ex.getMessage() != null && ex.getMessage().contains("Unable to find domain"));
+        }
+    }
+
+    @Test
+    public void convertField_withValidGlueType_returnsField()
+    {
+        handler = createElasticsearchMetadataHandler();
+
+        Field field = handler.convertField("myfield", "string");
+        assertNotNull("Field should not be null", field);
+        assertEquals("Field name should match", "myfield", field.getName());
+        assertNotNull("Field type should not be null", field.getType());
+    }
+
+    @Test
+    public void getDomainMap_returnsDomainMap()
+    {
+        when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of());
+
+        handler = createElasticsearchMetadataHandler();
+
+        Map<String, String> domainMap = handler.getDomainMap();
+        assertNotNull("Domain map should not be null", domainMap);
+        assertTrue("Domain map should be a valid map instance", domainMap instanceof Map);
+    }
+
+    /**
+     * Creates a handler with default configuration for reuse in tests.
+     * Should be called after setting up domainMapProvider mocks.
+     * @return a new ElasticsearchMetadataHandler instance
+     */
+    private ElasticsearchMetadataHandler createElasticsearchMetadataHandler()
+    {
+        return createElasticsearchMetadataHandler(ImmutableMap.of());
+    }
+
+    /**
+     * Creates a handler with custom configuration.
+     * @param configOptions custom configuration options
+     * @return a new ElasticsearchMetadataHandler instance
+     */
+    private ElasticsearchMetadataHandler createElasticsearchMetadataHandler(Map<String, String> configOptions)
+    {
+        return new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
+                SPILL_BUCKET, SPILL_PREFIX, domainMapProvider, clientFactory, DEFAULT_TIMEOUT, configOptions, false);
+    }
+
+    /**
+     * Creates query passthrough arguments map for testing.
+     *
+     * @param domain the schema/domain name
+     * @param index  the index name
+     * @return map of query passthrough arguments
+     */
+    private Map<String, String> createQueryPassthroughArgs(String domain, String index)
+    {
+        ElasticsearchQueryPassthrough qpt = new ElasticsearchQueryPassthrough();
+        return ImmutableMap.of(
+                QueryPassthroughSignature.SCHEMA_FUNCTION_NAME, qpt.getFunctionSignature(),
+                ElasticsearchQueryPassthrough.SCHEMA, domain,
+                ElasticsearchQueryPassthrough.INDEX, index,
+                ElasticsearchQueryPassthrough.QUERY, "test query");
+    }
+
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchQueryUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchQueryUtilsTest.java
@@ -28,8 +28,10 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,6 +46,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 
 /**
@@ -93,10 +97,16 @@ public class ElasticsearchQueryUtilsTest
                                         null))))).build();
     }
 
-    @Test
-    public void getProjectionTest()
+    @After
+    public void tearDown()
     {
-        logger.info("getProjectionTest - enter");
+        allocator.close();
+    }
+
+    @Test
+    public void getProjection_withMapping_returnsProjection()
+    {
+        logger.info("getProjection_withMapping_returnsProjection - enter");
 
         List<String> expectedProjection = new ArrayList<>();
         mapping.getFields().forEach(field -> expectedProjection.add(field.getName()));
@@ -108,13 +118,13 @@ public class ElasticsearchQueryUtilsTest
         logger.info("Projections - Expected: {}, Actual: {}", expectedProjection, actualProjection);
         assertEquals("Projections do not match", expectedProjection, actualProjection);
 
-        logger.info("getProjectionTest - exit");
+        logger.info("getProjection_withMapping_returnsProjection - exit");
     }
 
     @Test
-    public void getRangePredicateTest()
+    public void getQuery_withRangePredicate_returnsQueryBuilderRangePredicateString()
     {
-        logger.info("getRangePredicateTest - enter");
+        logger.info("getQuery_withRangePredicate_returnsQueryBuilderRangePredicateString - enter");
 
         constraintsMap.put("year", SortedRangeSet.copyOf(Types.MinorType.INT.getType(),
                 ImmutableList.of(
@@ -125,7 +135,7 @@ public class ElasticsearchQueryUtilsTest
                         Range.equal(allocator, Types.MinorType.INT.getType(), 1996),
                         Range.greaterThanOrEqual(allocator, Types.MinorType.INT.getType(), 2010)),
                 false));
-        Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        Constraints constraints = createConstraints(constraintsMap);
         String expectedPredicate = "(_exists_:year) AND year:([* TO 1950} OR {1955 TO 1972] OR [2010 TO *] OR 1952 OR 1996)";
 
         // Get the actual predicate and compare to the expected one.
@@ -135,17 +145,17 @@ public class ElasticsearchQueryUtilsTest
         logger.info("Predicates - Expected: {}, Actual: {}", expectedPredicate, actualPredicate);
         assertEquals("Predicates do not match", expectedPredicate, actualPredicate);
 
-        logger.info("getRangePredicateTest - exit");
+        logger.info("getQuery_withRangePredicate_returnsQueryBuilderRangePredicateString - exit");
     }
 
     @Test
-    public void getWhitelistedEquitableValuesPredicate()
+    public void getQuery_withWhitelistedEquitableValues_returnsQueryBuilderOrClause()
     {
-        logger.info("getWhitelistedEquitableValuesPredicate - enter");
+        logger.info("getQuery_withWhitelistedEquitableValues_returnsQueryBuilderOrClause - enter");
 
         constraintsMap.put("age", EquatableValueSet.newBuilder(allocator, Types.MinorType.INT.getType(),
                 true, true).addAll(ImmutableList.of(20, 25, 30, 35)).build());
-                Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        Constraints constraints = createConstraints(constraintsMap);
         String expectedPredicate = "age:(20 OR 25 OR 30 OR 35)";
 
         // Get the actual predicate and compare to the expected one.
@@ -155,17 +165,17 @@ public class ElasticsearchQueryUtilsTest
         logger.info("Predicates - Expected: {}, Actual: {}", expectedPredicate, actualPredicate);
         assertEquals("Predicates do not match", expectedPredicate, actualPredicate);
 
-        logger.info("getWhitelistedEquitableValuesPredicate - exit");
+        logger.info("getQuery_withWhitelistedEquitableValues_returnsQueryBuilderOrClause - exit");
     }
 
     @Test
-    public void getExclusiveEquitableValuesPredicate()
+    public void getQuery_withExclusiveEquitableValues_returnsQueryBuilderNotOrClause()
     {
-        logger.info("getExclusiveEquitableValuesPredicate - enter");
+        logger.info("getQuery_withExclusiveEquitableValues_returnsQueryBuilderNotOrClause - enter");
 
         constraintsMap.put("age", EquatableValueSet.newBuilder(allocator, Types.MinorType.INT.getType(),
                 false, true).addAll(ImmutableList.of(20, 25, 30, 35)).build());
-        Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        Constraints constraints = createConstraints(constraintsMap);
         String expectedPredicate = "NOT age:(20 OR 25 OR 30 OR 35)";
 
         // Get the actual predicate and compare to the expected one.
@@ -175,16 +185,16 @@ public class ElasticsearchQueryUtilsTest
         logger.info("Predicates - Expected: {}, Actual: {}", expectedPredicate, actualPredicate);
         assertEquals("Predicates do not match", expectedPredicate, actualPredicate);
 
-        logger.info("getExclusiveEquitableValuesPredicate - exit");
+        logger.info("getQuery_withExclusiveEquitableValues_returnsQueryBuilderNotOrClause - exit");
     }
 
     @Test
-    public void getAllValuePredicate()
+    public void getQuery_withAllValuePredicate_returnsQueryBuilderExistsClause()
     {
-        logger.info("getAllValuePredicate - enter");
+        logger.info("getQuery_withAllValuePredicate_returnsQueryBuilderExistsClause - enter");
 
         constraintsMap.put("number", new AllOrNoneValueSet(Types.MinorType.INT.getType(), true, true));
-        Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        Constraints constraints = createConstraints(constraintsMap);
         String expectedPredicate = "(_exists_:number)";
 
         // Get the actual predicate and compare to the expected one.
@@ -194,16 +204,16 @@ public class ElasticsearchQueryUtilsTest
         logger.info("Predicates - Expected: {}, Actual: {}", expectedPredicate, actualPredicate);
         assertEquals("Predicates do not match", expectedPredicate, actualPredicate);
 
-        logger.info("getAllValuePredicate - exit");
+        logger.info("getQuery_withAllValuePredicate_returnsQueryBuilderExistsClause - exit");
     }
 
     @Test
-    public void getNoneValuePredicate()
+    public void getQuery_withNoneValuePredicate_returnsQueryBuilderNotExistsClause()
     {
-        logger.info("getNoneValuePredicate - enter");
+        logger.info("getQuery_withNoneValuePredicate_returnsQueryBuilderNotExistsClause - enter");
 
         constraintsMap.put("number", new AllOrNoneValueSet(Types.MinorType.INT.getType(), false, false));
-        Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        Constraints constraints = createConstraints(constraintsMap);
         String expectedPredicate = "(NOT _exists_:number)";
 
         // Get the actual predicate and compare to the expected one.
@@ -213,6 +223,118 @@ public class ElasticsearchQueryUtilsTest
         logger.info("Predicates - Expected: {}, Actual: {}", expectedPredicate, actualPredicate);
         assertEquals("Predicates do not match", expectedPredicate, actualPredicate);
 
-        logger.info("getNoneValuePredicate - exit");
+        logger.info("getQuery_withNoneValuePredicate_returnsQueryBuilderNotExistsClause - exit");
     }
+
+    @Test
+    public void getQuery_withDateSingleValueInRange_wrapsDateInQuotes()
+    {
+        Map<String, ValueSet> summary = new HashMap<>();
+        summary.put("mydate", SortedRangeSet.copyOf(Types.MinorType.DATEMILLI.getType(),
+                ImmutableList.of(Range.equal(allocator, Types.MinorType.DATEMILLI.getType(), 1589525370001L)), false));
+        Constraints constraints = createConstraints(summary);
+
+        QueryBuilder builder = ElasticsearchQueryUtils.getQuery(constraints);
+        String actualPredicate = builder.queryName();
+        assertTrue("Predicate for single date value should wrap value in quotes", actualPredicate.contains("mydate:(\""));
+        assertTrue("Predicate should contain quoted value", actualPredicate.contains("\")"));
+    }
+
+    @Test
+    public void getQuery_withExclusiveLowBound_returnsQueryBuilderExclusiveLowBoundRange()
+    {
+        Map<String, ValueSet> summary = new HashMap<>();
+        summary.put("myfield", SortedRangeSet.copyOf(Types.MinorType.INT.getType(),
+                ImmutableList.of(Range.range(allocator, Types.MinorType.INT.getType(), 10, false, 20, true)), false));
+        Constraints constraints = createConstraints(summary);
+
+        QueryBuilder builder = ElasticsearchQueryUtils.getQuery(constraints);
+        assertNotNull("Should successfully create query builder for range with exclusive low bound", builder);
+        String actualPredicate = builder.queryName();
+        assertTrue("Exclusive low bound should use '{' in range syntax", actualPredicate.contains("{"));
+    }
+
+    @Test
+    public void getQuery_withExclusiveHighBound_returnsQueryBuilderExclusiveHighBoundRange()
+    {
+        Map<String, ValueSet> summary = new HashMap<>();
+        summary.put("myfield", SortedRangeSet.copyOf(Types.MinorType.INT.getType(),
+                ImmutableList.of(Range.range(allocator, Types.MinorType.INT.getType(), 10, true, 20, false)), false));
+        Constraints constraints = createConstraints(summary);
+
+        QueryBuilder builder = ElasticsearchQueryUtils.getQuery(constraints);
+        assertNotNull("Should successfully create query builder for range with exclusive high bound", builder);
+        String actualPredicate = builder.queryName();
+        assertTrue("Exclusive high bound should use '}' in range syntax", actualPredicate.contains("}"));
+    }
+
+    @Test
+    public void getQuery_withInclusiveRange_returnsQueryBuilderInclusiveRangeClause()
+    {
+        Map<String, ValueSet> summary = new HashMap<>();
+        summary.put("myfield", SortedRangeSet.copyOf(Types.MinorType.INT.getType(),
+                ImmutableList.of(Range.range(allocator, Types.MinorType.INT.getType(), 10, true, 20, true)), false));
+        Constraints constraints = createConstraints(summary);
+
+        QueryBuilder builder = ElasticsearchQueryUtils.getQuery(constraints);
+        assertNotNull("Should successfully create query builder for inclusive range", builder);
+        String actualPredicate = builder.queryName();
+        assertTrue("Inclusive range should use '[' in range syntax", actualPredicate.contains("["));
+        assertTrue("Inclusive range should use ']' in range syntax", actualPredicate.contains("]"));
+    }
+
+    @Test
+    public void getQuery_withEmptyRangeSet_returnsQueryBuilderMatchAllQuery()
+    {
+        // Test getPredicateFromRange indirectly through getQuery with empty range set
+        SortedRangeSet emptyRangeSet = SortedRangeSet.copyOf(Types.MinorType.INT.getType(), Collections.emptyList(), false);
+        Map<String, ValueSet> constraintSummary = new HashMap<>();
+        constraintSummary.put("myfield", emptyRangeSet);
+        Constraints constraints = createConstraints(constraintSummary);
+
+        QueryBuilder result = ElasticsearchQueryUtils.getQuery(constraints);
+
+        assertNotNull("Should return query builder", result);
+    }
+
+    @Test
+    public void getQuery_withEmptyConstraints_returnsQueryBuilderMatchAllQuery()
+    {
+        Constraints emptyConstraints = createConstraints(Collections.emptyMap());
+
+        QueryBuilder builder = ElasticsearchQueryUtils.getQuery(emptyConstraints);
+        assertNotNull("Query builder should not be null for empty constraints", builder);
+        assertTrue("Empty constraints should produce MatchAllQueryBuilder", builder instanceof MatchAllQueryBuilder);
+    }
+
+    @Test
+    public void getQuery_withRangeSet_returnsQueryBuilderRangeSet()
+    {
+        // Test getPredicateFromRange indirectly through getQuery with valid range set
+        // Note: Testing BELOW/ABOVE marker edge cases requires reflection which is not compatible with Java 17+
+        // These edge cases are internal implementation details and should be tested through integration tests
+        Range range = Range.range(allocator, Types.MinorType.INT.getType(), 10, true, 20, true);
+        SortedRangeSet rangeSet = SortedRangeSet.copyOf(Types.MinorType.INT.getType(), ImmutableList.of(range), false);
+        
+        Map<String, ValueSet> constraintSummary = new HashMap<>();
+        constraintSummary.put("myfield", rangeSet);
+        Constraints constraints = createConstraints(constraintSummary);
+
+        QueryBuilder result = ElasticsearchQueryUtils.getQuery(constraints);
+
+        assertNotNull("Should return query builder for range set", result);
+        String actualPredicate = result.queryName();
+        assertTrue("Range set predicate should contain field name myfield", actualPredicate.contains("myfield"));
+        assertTrue("Range set predicate should contain lower bound 10", actualPredicate.contains("10"));
+        assertTrue("Range set predicate should contain upper bound 20", actualPredicate.contains("20"));
+    }
+
+    /**
+     * Creates a Constraints instance from the given constraint summary map.
+     */
+    private Constraints createConstraints(Map<String, ValueSet> summary)
+    {
+        return new Constraints(summary, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+    }
+
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -86,8 +86,8 @@ import java.util.UUID;
 
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
@@ -540,15 +540,11 @@ public class ElasticsearchRecordHandlerTest
 
         BlockSpiller spiller = mock(BlockSpiller.class);
 
-        try {
-            handler.readWithConstraint(spiller, request, queryStatusChecker);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain Error sending search query",
-                    ex.getMessage() != null && ex.getMessage().contains("Error sending search query"));
-            assertTrue("Exception message should contain original error",
-                    ex.getMessage() != null && ex.getMessage().contains("Search failed"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> handler.readWithConstraint(spiller, request, queryStatusChecker));
+        assertTrue("Exception message should contain Error sending search query",
+                ex.getMessage() != null && ex.getMessage().contains("Error sending search query"));
+        assertTrue("Exception message should contain original error",
+                ex.getMessage() != null && ex.getMessage().contains("Search failed"));
     }
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-example
+ * athena-elasticsearch
  * %%
  * Copyright (C) 2019 Amazon Web Services
  * %%
@@ -27,9 +27,12 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.domain.spill.S3SpillLocation;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
@@ -84,12 +87,13 @@ import java.util.UUID;
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * This class is used to test the ElasticsearchRecordHandler class.
@@ -98,6 +102,7 @@ import static org.mockito.Mockito.verify;
 public class ElasticsearchRecordHandlerTest
 {
     private static final Logger logger = LoggerFactory.getLogger(ElasticsearchRecordHandlerTest.class);
+    private static final String TEST_QUERY_ID = "queryId-1";
 
     private ElasticsearchRecordHandler handler;
     private BlockAllocatorImpl allocator;
@@ -316,16 +321,16 @@ public class ElasticsearchRecordHandlerTest
     }
 
     @After
-    public void after()
+    public void tearDown()
     {
         allocator.close();
     }
 
     @Test
-    public void doReadRecordsNoSpill()
+    public void readRecords_withNoSpill_returnsRecordsInMemory()
             throws Exception
     {
-        logger.info("doReadRecordsNoSpill: enter");
+        logger.info("readRecords_withNoSpill_returnsRecordsInMemory: enter");
 
         SearchHit searchHit[] = new SearchHit[2];
         searchHit[0] = new SearchHit(1);
@@ -346,7 +351,7 @@ public class ElasticsearchRecordHandlerTest
 
         ReadRecordsRequest request = new ReadRecordsRequest(fakeIdentity(),
                 "elasticsearch",
-                "queryId-" + System.currentTimeMillis(),
+                TEST_QUERY_ID,
                 new TableName("movies", "mishmash"),
                 mapping,
                 split,
@@ -372,7 +377,7 @@ public class ElasticsearchRecordHandlerTest
         assertTrue(rawResponse instanceof ReadRecordsResponse);
 
         ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
-        logger.info("doReadRecordsNoSpill: rows[{}]", response.getRecordCount());
+        logger.info("readRecords_withNoSpill_returnsRecordsInMemory: rows[{}]", response.getRecordCount());
 
         assertEquals(2, response.getRecords().getRowCount());
         for (int i = 0; i < response.getRecords().getRowCount(); ++i) {
@@ -380,14 +385,14 @@ public class ElasticsearchRecordHandlerTest
             assertEquals(expectedDocuments[i], BlockUtils.rowToString(response.getRecords(), i));
         }
 
-        logger.info("doReadRecordsNoSpill: exit");
+        logger.info("readRecords_withNoSpill_returnsRecordsInMemory: exit");
     }
 
     @Test
-    public void doReadRecordsSpill()
+    public void readRecords_withSpill_returnsRecordsFromSpilledBlocks()
             throws Exception
     {
-        logger.info("doReadRecordsSpill: enter");
+        logger.info("readRecords_withSpill_returnsRecordsFromSpilledBlocks: enter");
 
         int batchSize = handler.getQueryBatchSize();
         SearchHit searchHit1[] = new SearchHit[batchSize];
@@ -412,7 +417,7 @@ public class ElasticsearchRecordHandlerTest
 
         ReadRecordsRequest request = new ReadRecordsRequest(fakeIdentity(),
                 "elasticsearch",
-                "queryId-" + System.currentTimeMillis(),
+                TEST_QUERY_ID,
                 new TableName("movies", "mishmash"),
                 mapping,
                 split,
@@ -426,7 +431,7 @@ public class ElasticsearchRecordHandlerTest
         assertTrue(rawResponse instanceof RemoteReadRecordsResponse);
 
         try (RemoteReadRecordsResponse response = (RemoteReadRecordsResponse) rawResponse) {
-            logger.info("doReadRecordsSpill: remoteBlocks[{}]", response.getRemoteBlocks().size());
+            logger.info("readRecords_withSpill_returnsRecordsFromSpilledBlocks: remoteBlocks[{}]", response.getRemoteBlocks().size());
 
             assertEquals(1, response.getNumberBlocks());
 
@@ -434,17 +439,17 @@ public class ElasticsearchRecordHandlerTest
             for (SpillLocation next : response.getRemoteBlocks()) {
                 S3SpillLocation spillLocation = (S3SpillLocation) next;
                 try (Block block = spillReader.read(spillLocation, response.getEncryptionKey(), response.getSchema())) {
-                    logger.info("doReadRecordsSpill: blockNum[{}] and recordCount[{}]", blockNum++, block.getRowCount());
+                    logger.info("readRecords_withSpill_returnsRecordsFromSpilledBlocks: blockNum[{}] and recordCount[{}]", blockNum++, block.getRowCount());
                     assertEquals(expectedDocuments.length, block.getRowCount());
                     for (int rowCount = 0; rowCount < block.getRowCount(); rowCount++) {
-                        logger.info("doReadRecordsSpill: {}", BlockUtils.rowToString(block, rowCount));
+                        logger.info("readRecords_withSpill_returnsRecordsFromSpilledBlocks: {}", BlockUtils.rowToString(block, rowCount));
                         assertEquals(expectedDocuments[rowCount], BlockUtils.rowToString(block, rowCount));
                     }
                 }
             }
         }
 
-        logger.info("doReadRecordsSpill: exit");
+        logger.info("readRecords_withSpill_returnsRecordsFromSpilledBlocks: exit");
     }
 
     private class ByteHolder
@@ -480,5 +485,70 @@ public class ElasticsearchRecordHandlerTest
                 .withSplitId(UUID.randomUUID().toString())
                 .withIsDirectory(true)
                 .build();
+    }
+
+    @Test
+    public void readWithConstraint_whenQueryNotRunning_doesNotProcessRecords()
+            throws Exception
+    {
+        logger.info("readWithConstraint_whenQueryNotRunning_doesNotProcessRecords - enter");
+
+        QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
+        when(queryStatusChecker.isQueryRunning()).thenReturn(false);
+
+        ReadRecordsRequest request = new ReadRecordsRequest(fakeIdentity(),
+                "elasticsearch",
+                TEST_QUERY_ID,
+                new TableName("movies", "mishmash"),
+                mapping,
+                split,
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                100_000_000_000L,
+                100_000_000_000L
+        );
+
+        BlockSpiller spiller = mock(BlockSpiller.class);
+
+        handler.readWithConstraint(spiller, request, queryStatusChecker);
+
+        verify(mockClient, never()).search(any(), any());
+
+        logger.info("readWithConstraint_whenQueryNotRunning_doesNotProcessRecords - exit");
+    }
+
+    @Test
+    public void readWithConstraint_whenIOException_throwsAthenaConnectorException()
+            throws Exception
+    {
+        logger.info("readWithConstraint_whenIOException_throwsAthenaConnectorException - enter");
+
+        QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
+        when(queryStatusChecker.isQueryRunning()).thenReturn(true);
+
+        when(mockClient.search(any(), any())).thenThrow(new IOException("Search failed"));
+
+        ReadRecordsRequest request = new ReadRecordsRequest(fakeIdentity(),
+                "elasticsearch",
+                TEST_QUERY_ID,
+                new TableName("movies", "mishmash"),
+                mapping,
+                split,
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                100_000_000_000L,
+                100_000_000_000L
+        );
+
+        BlockSpiller spiller = mock(BlockSpiller.class);
+
+        try {
+            handler.readWithConstraint(spiller, request, queryStatusChecker);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain Error sending search query",
+                    ex.getMessage() != null && ex.getMessage().contains("Error sending search query"));
+            assertTrue("Exception message should contain original error",
+                    ex.getMessage() != null && ex.getMessage().contains("Search failed"));
+        }
     }
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchSchemaUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchSchemaUtilsTest.java
@@ -44,8 +44,8 @@ import java.util.Map;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * This class is used to test the ElasticsearchSchemaUtils class.
@@ -348,14 +348,10 @@ public class ElasticsearchSchemaUtilsTest
 
         logger.info("parseMapping_withInvalidMeta_throwsAthenaConnectorException - enter");
 
-        try {
-            ElasticsearchSchemaUtils.parseMapping(actual);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain _meta only support value",
-                    ex.getMessage().contains("_meta only support value"));
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> ElasticsearchSchemaUtils.parseMapping(actual));
+        assertTrue("Exception message should contain _meta only support value",
+                ex.getMessage().contains("_meta only support value"));
 
         logger.info("parseMapping_withInvalidMeta_throwsAthenaConnectorException - exit");
     }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchSchemaUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchSchemaUtilsTest.java
@@ -39,8 +39,13 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * This class is used to test the ElasticsearchSchemaUtils class.
@@ -161,9 +166,9 @@ public class ElasticsearchSchemaUtilsTest
     }
 
     @Test
-    public void parseMappingTest()
+    public void parseMapping_withValidMapping_returnsSchema()
     {
-        logger.info("parseMappingTest - enter");
+        logger.info("parseMapping_withValidMapping_returnsSchema - enter");
 
         Schema builtSchema = ElasticsearchSchemaUtils.parseMapping(mapping);
 
@@ -171,11 +176,11 @@ public class ElasticsearchSchemaUtilsTest
         assertTrue("Real and mocked mappings are different!",
                 ElasticsearchSchemaUtils.mappingsEqual(expectedSchema, builtSchema));
 
-        logger.info("parseMappingTest - exit");
+        logger.info("parseMapping_withValidMapping_returnsSchema - exit");
     }
 
     @Test
-    public void parseSchemaWithListOfStruct()
+    public void parseMapping_withListOfStruct_returnsSchema()
             throws JsonProcessingException
     {
 
@@ -262,18 +267,18 @@ public class ElasticsearchSchemaUtilsTest
                 "      }\n" +
                 "    }", LinkedHashMap.class);
 
-        logger.info("parseSchemaWithListOfStruct - enter");
+        logger.info("parseMapping_withListOfStruct_returnsSchema - enter");
 
         Schema builtSchema = ElasticsearchSchemaUtils.parseMapping(actual);
         // The built mapping and expected mapping should match.
         assertTrue("Real and mocked mappings are different!",
                 ElasticsearchSchemaUtils.mappingsEqual(expected, builtSchema));
 
-        logger.info("parseSchemaWithListOfStruct - exit");
+        logger.info("parseMapping_withListOfStruct_returnsSchema - exit");
     }
 
-    @Test(expected = AthenaConnectorException.class)
-    public void parseMappingWithInvalidMeta()
+    @Test
+    public void parseMapping_withInvalidMeta_throwsAthenaConnectorException()
             throws JsonProcessingException
     {
         LinkedHashMap actual = new ObjectMapper().readValue(" {\n" +
@@ -341,10 +346,147 @@ public class ElasticsearchSchemaUtilsTest
                 "      }\n" +
                 "    }", LinkedHashMap.class);
 
-        logger.info("parseMappingWithInvalidMeta - enter");
+        logger.info("parseMapping_withInvalidMeta_throwsAthenaConnectorException - enter");
 
-        Schema builtSchema = ElasticsearchSchemaUtils.parseMapping(actual);
+        try {
+            ElasticsearchSchemaUtils.parseMapping(actual);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain _meta only support value",
+                    ex.getMessage().contains("_meta only support value"));
+        }
 
-        logger.info("parseMappingWithInvalidMeta - exit");
+        logger.info("parseMapping_withInvalidMeta_throwsAthenaConnectorException - exit");
+    }
+
+    @Test
+    public void parseMapping_withUnknownType_returnsFieldWithNullType()
+    {
+        Map<String, Object> field1 = new LinkedHashMap<>();
+        field1.put("type", "unknown_type");
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("field1", field1);
+        Map<String, Object> mapping = new LinkedHashMap<>();
+        mapping.put("properties", properties);
+
+        Schema schema = ElasticsearchSchemaUtils.parseMapping(mapping);
+        Field field = schema.findField("field1");
+        
+        assertNotNull("Schema should contain field1", field);
+        assertSame("Should return NULL type for unknown type", Types.MinorType.NULL, Types.getMinorTypeForArrowType(field.getType()));
+    }
+
+    @Test
+    public void mappingsEqual_withDifferentSizes_returnsFalse()
+    {
+        Schema schema1 = SchemaBuilder.newBuilder()
+                .addField("field1", Types.MinorType.VARCHAR.getType())
+                .build();
+        Schema schema2 = SchemaBuilder.newBuilder()
+                .addField("field1", Types.MinorType.VARCHAR.getType())
+                .addField("field2", Types.MinorType.INT.getType())
+                .build();
+
+        boolean result = ElasticsearchSchemaUtils.mappingsEqual(schema1, schema2);
+        assertFalse("mappingsEqual should return false when schema sizes differ", result);
+    }
+
+    @Test
+    public void mappingsEqual_withDifferentFieldTypes_returnsFalse()
+    {
+        Schema schema1 = SchemaBuilder.newBuilder()
+                .addField("field1", Types.MinorType.VARCHAR.getType())
+                .build();
+        Schema schema2 = SchemaBuilder.newBuilder()
+                .addField("field1", Types.MinorType.INT.getType())
+                .build();
+
+        boolean result = ElasticsearchSchemaUtils.mappingsEqual(schema1, schema2);
+        assertFalse("mappingsEqual should return false when field types differ", result);
+    }
+
+    @Test
+    public void mappingsEqual_withDifferentMetadata_returnsFalse()
+    {
+        Schema schema1 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", new FieldType(true, Types.MinorType.BIGINT.getType(), null,
+                        ImmutableMap.of("scaling_factor", "100")), null))
+                .build();
+        Schema schema2 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", new FieldType(true, Types.MinorType.BIGINT.getType(), null,
+                        ImmutableMap.of("scaling_factor", "200")), null))
+                .build();
+
+        boolean result = ElasticsearchSchemaUtils.mappingsEqual(schema1, schema2);
+        assertFalse("mappingsEqual should return false when metadata differs", result);
+    }
+
+    @Test
+    public void mappingsEqual_withDifferentChildSizes_returnsFalse()
+    {
+        Schema schema1 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                        ImmutableList.of(new Field("child1", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null))))
+                .build();
+        Schema schema2 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                        ImmutableList.of(
+                                new Field("child1", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null),
+                                new Field("child2", FieldType.nullable(Types.MinorType.INT.getType()), null))))
+                .build();
+
+        boolean result = ElasticsearchSchemaUtils.mappingsEqual(schema1, schema2);
+        assertFalse("mappingsEqual should return false when child sizes differ", result);
+    }
+
+    @Test
+    public void mappingsEqual_withDifferentChildNames_returnsFalse()
+    {
+        Schema schema1 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                        ImmutableList.of(new Field("child1", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null))))
+                .build();
+        Schema schema2 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                        ImmutableList.of(new Field("child2", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null))))
+                .build();
+
+        boolean result = ElasticsearchSchemaUtils.mappingsEqual(schema1, schema2);
+        assertFalse("mappingsEqual should return false when child names differ", result);
+    }
+
+    @Test
+    public void mappingsEqual_withDifferentChildFieldTypes_returnsFalse()
+    {
+        Schema schema1 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                        ImmutableList.of(new Field("child1", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null))))
+                .build();
+        Schema schema2 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                        ImmutableList.of(new Field("child1", FieldType.nullable(Types.MinorType.INT.getType()), null))))
+                .build();
+
+        boolean result = ElasticsearchSchemaUtils.mappingsEqual(schema1, schema2);
+        assertFalse("mappingsEqual should return false when child field types differ", result);
+    }
+
+    @Test
+    public void mappingsEqual_withDifferentChildMetadata_returnsFalse()
+    {
+        Schema schema1 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                        ImmutableList.of(new Field("child1", new FieldType(true, Types.MinorType.BIGINT.getType(), null,
+                                ImmutableMap.of("scaling_factor", "100")), null))))
+                .build();
+        Schema schema2 = SchemaBuilder.newBuilder()
+                .addField(new Field("field1", FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                        ImmutableList.of(new Field("child1", new FieldType(true, Types.MinorType.BIGINT.getType(), null,
+                                ImmutableMap.of("scaling_factor", "200")), null))))
+                .build();
+
+        boolean result = ElasticsearchSchemaUtils.mappingsEqual(schema1, schema2);
+        assertFalse("mappingsEqual should return false when child metadata differs", result);
     }
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchTypeUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchTypeUtilsTest.java
@@ -51,10 +51,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * This class is used to test the ElasticsearchTypeUtils class.
@@ -71,10 +75,10 @@ public class ElasticsearchTypeUtilsTest
      * @throws Exception
      */
     @Test
-    public void makeVarCharExtractorTest()
+    public void makeVarCharExtractor_withDocument_extractsVarCharValues()
             throws Exception
     {
-        logger.info("makeVarCharExtractorTest - enter");
+        logger.info("makeVarCharExtractor_withDocument_extractsVarCharValues - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField("mytext", Types.MinorType.VARCHAR.getType())
@@ -94,10 +98,10 @@ public class ElasticsearchTypeUtilsTest
                 "mytext", "My favorite Sci-Fi movie is Interstellar.",
                 "mytextlist", "[Hey, this is an array!, Wasn't expecting this!]");
         Map<String, Object> extractedResults = testField(mapping, document);
-        logger.info("makeVarCharExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeVarCharExtractor_withDocument_extractsVarCharValues - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
 
-        logger.info("makeVarCharExtractorTest - exit");
+        logger.info("makeVarCharExtractor_withDocument_extractsVarCharValues - exit");
     }
 
     /**
@@ -105,10 +109,10 @@ public class ElasticsearchTypeUtilsTest
      * @throws Exception
      */
     @Test
-    public void makeBigIntExtractorTest()
+    public void makeBigIntExtractor_withDocument_extractsBigIntValues()
             throws Exception
     {
-        logger.info("makeBigIntExtractorTest - enter");
+        logger.info("makeBigIntExtractor_withDocument_extractsBigIntValues - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField(new Field("myscaledfloat",
@@ -163,10 +167,10 @@ public class ElasticsearchTypeUtilsTest
         expectedResults.put("mylonglist", new Long(2374637));
         expectedResults.put("mylongstringlist", new Long(945857834));
         Map<String, Object> extractedResults = testField(mapping, document);
-        logger.info("makeBigIntExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeBigIntExtractor_withDocument_extractsBigIntValues - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
 
-        logger.info("makeBigIntExtractorTest - exit");
+        logger.info("makeBigIntExtractor_withDocument_extractsBigIntValues - exit");
     }
 
     /**
@@ -174,10 +178,10 @@ public class ElasticsearchTypeUtilsTest
      * @throws Exception
      */
     @Test
-    public void makeIntExtractorTest()
+    public void makeIntExtractor_withDocument_extractsIntValues()
             throws Exception
     {
-        logger.info("makeIntExtractorTest - enter");
+        logger.info("makeIntExtractor_withDocument_extractsIntValues - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField("myint", Types.MinorType.INT.getType())
@@ -206,10 +210,10 @@ public class ElasticsearchTypeUtilsTest
                 "myintlist", new Integer(472394),
                 "myintstringlist", new Integer(34875934));
         Map<String, Object> extractedResults = testField(mapping, document);
-        logger.info("makeIntExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeIntExtractor_withDocument_extractsIntValues - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
 
-        logger.info("makeIntExtractorTest - exit");
+        logger.info("makeIntExtractor_withDocument_extractsIntValues - exit");
     }
 
     /**
@@ -217,10 +221,10 @@ public class ElasticsearchTypeUtilsTest
      * @throws Exception
      */
     @Test
-    public void makeSmallIntExtractorTest()
+    public void makeSmallIntExtractor_withDocument_extractsSmallIntValues()
             throws Exception
     {
-        logger.info("makeSmallIntExtractorTest - enter");
+        logger.info("makeSmallIntExtractor_withDocument_extractsSmallIntValues - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField("myshort", Types.MinorType.SMALLINT.getType())
@@ -249,10 +253,10 @@ public class ElasticsearchTypeUtilsTest
                 "myshortlist", new Short((short) 543),
                 "myshortstringlist", new Short((short) 334));
         Map<String, Object> extractedResults = testField(mapping, document);
-        logger.info("makeSmallIntExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeSmallIntExtractor_withDocument_extractsSmallIntValues - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
 
-        logger.info("makeSmallIntExtractorTest - exit");
+        logger.info("makeSmallIntExtractor_withDocument_extractsSmallIntValues - exit");
     }
 
     /**
@@ -260,10 +264,10 @@ public class ElasticsearchTypeUtilsTest
      * @throws Exception
      */
     @Test
-    public void makeTinyIntExtractorTest()
+    public void makeTinyIntExtractor_withDocument_extractsTinyIntValues()
             throws Exception
     {
-        logger.info("makeTinyIntExtractorTest - enter");
+        logger.info("makeTinyIntExtractor_withDocument_extractsTinyIntValues - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField("mybyte", Types.MinorType.TINYINT.getType())
@@ -292,10 +296,10 @@ public class ElasticsearchTypeUtilsTest
                 "mybytelist", new Byte((byte) 1),
                 "mybytestringlist", new Byte((byte) 3));
         Map<String, Object> extractedResults = testField(mapping, document);
-        logger.info("makeTinyIntExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeTinyIntExtractor_withDocument_extractsTinyIntValues - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
 
-        logger.info("makeTinyIntExtractorTest - exit");
+        logger.info("makeTinyIntExtractor_withDocument_extractsTinyIntValues - exit");
     }
 
     /**
@@ -303,10 +307,10 @@ public class ElasticsearchTypeUtilsTest
      * @throws Exception
      */
     @Test
-    public void makeFloat8ExtractorTest()
+    public void makeFloat8Extractor_withDocument_extractsFloat8Values()
             throws Exception
     {
-        logger.info("makeFloat8ExtractorTest - enter");
+        logger.info("makeFloat8Extractor_withDocument_extractsFloat8Values - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField("mydouble", Types.MinorType.FLOAT8.getType())
@@ -335,10 +339,10 @@ public class ElasticsearchTypeUtilsTest
                 "mydoublelist", new Double(65.0),
                 "mydoublestringlist", new Double(10.0));
         Map<String, Object> extractedResults = testField(mapping, document);
-        logger.info("makeFloat8ExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeFloat8Extractor_withDocument_extractsFloat8Values - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
 
-        logger.info("makeFloat8ExtractorTest - exit");
+        logger.info("makeFloat8Extractor_withDocument_extractsFloat8Values - exit");
     }
 
     /**
@@ -346,10 +350,10 @@ public class ElasticsearchTypeUtilsTest
      * @throws Exception
      */
     @Test
-    public void makeFloat4ExtractorTest()
+    public void makeFloat4Extractor_withDocument_extractsFloat4Values()
             throws Exception
     {
-        logger.info("makeFloat4ExtractorTest - enter");
+        logger.info("makeFloat4Extractor_withDocument_extractsFloat4Values - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField("myfloat", Types.MinorType.FLOAT4.getType())
@@ -378,10 +382,10 @@ public class ElasticsearchTypeUtilsTest
                 "myfloatlist", new Float(23.0),
                 "myfloatstringlist", new Float(45.0));
         Map<String, Object> extractedResults = testField(mapping, document);
-        logger.info("makeFloat4ExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeFloat4Extractor_withDocument_extractsFloat4Values - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
 
-        logger.info("makeFloat4ExtractorTest - exit");
+        logger.info("makeFloat4Extractor_withDocument_extractsFloat4Values - exit");
     }
 
     /**
@@ -389,10 +393,10 @@ public class ElasticsearchTypeUtilsTest
      * @throws Exception
      */
     @Test
-    public void makeDateMilliExtractorTest()
+    public void makeDateMilliExtractor_withDocument_extractsDateMilliValues()
             throws Exception
     {
-        logger.info("makeDateMilliExtractorTest - enter");
+        logger.info("makeDateMilliExtractor_withDocument_extractsDateMilliValues - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField("mydate", Types.MinorType.DATEMILLI.getType())
@@ -421,10 +425,10 @@ public class ElasticsearchTypeUtilsTest
                 "mydatelist", new Long("1589969730789"),
                 "mydatestringlist", new Long("1589543370123"));
         Map<String, Object> extractedResults = testField(mapping, document);
-        logger.info("makeDateMilliExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeDateMilliExtractor_withDocument_extractsDateMilliValues - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
 
-        logger.info("makeDateMilliExtractorTest - exit");
+        logger.info("makeDateMilliExtractor_withDocument_extractsDateMilliValues - exit");
     }
 
     /**
@@ -432,10 +436,10 @@ public class ElasticsearchTypeUtilsTest
      * @throws Exception
      */
     @Test
-    public void makeBooleanExtractorTest()
+    public void makeBitExtractor_withDocument_extractsBitValues()
             throws Exception
     {
-        logger.info("makeBooleanExtractorTest - enter");
+        logger.info("makeBitExtractor_withDocument_extractsBitValues - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField("myboolean", Types.MinorType.BIT.getType())
@@ -464,10 +468,10 @@ public class ElasticsearchTypeUtilsTest
                 "mybooleanlist", 0,
                 "mybooleanstringlist", 1);
         Map<String, Object> extractedResults = testField(mapping, document);
-        logger.info("makeBooleanExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeBitExtractor_withDocument_extractsBitValues - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
 
-        logger.info("makeBooleanExtractorTest - exit");
+        logger.info("makeBitExtractor_withDocument_extractsBitValues - exit");
     }
 
     /**
@@ -483,62 +487,632 @@ public class ElasticsearchTypeUtilsTest
         Map<String, Object> results = new HashMap<>();
         for (Field field : mapping.getFields()) {
             Extractor extractor = typeUtils.makeExtractor(field);
-            if (extractor instanceof VarCharExtractor) {
-                NullableVarCharHolder holder = new NullableVarCharHolder();
-                ((VarCharExtractor) extractor).extract(document, holder);
-                assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
-                results.put(field.getName(), holder.value);
-            }
-            else if (extractor instanceof BigIntExtractor) {
-                NullableBigIntHolder holder = new NullableBigIntHolder();
-                ((BigIntExtractor) extractor).extract(document, holder);
-                assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
-                results.put(field.getName(), holder.value);
-            }
-            else if (extractor instanceof IntExtractor) {
-                NullableIntHolder holder = new NullableIntHolder();
-                ((IntExtractor) extractor).extract(document, holder);
-                assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
-                results.put(field.getName(), holder.value);
-            }
-            else if (extractor instanceof SmallIntExtractor) {
-                NullableSmallIntHolder holder = new NullableSmallIntHolder();
-                ((SmallIntExtractor) extractor).extract(document, holder);
-                assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
-                results.put(field.getName(), holder.value);
-            }
-            else if (extractor instanceof TinyIntExtractor) {
-                NullableTinyIntHolder holder = new NullableTinyIntHolder();
-                ((TinyIntExtractor) extractor).extract(document, holder);
-                assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
-                results.put(field.getName(), holder.value);
-            }
-            else if (extractor instanceof Float8Extractor) {
-                NullableFloat8Holder holder = new NullableFloat8Holder();
-                ((Float8Extractor) extractor).extract(document, holder);
-                assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
-                results.put(field.getName(), holder.value);
-            }
-            else if (extractor instanceof Float4Extractor) {
-                NullableFloat4Holder holder = new NullableFloat4Holder();
-                ((Float4Extractor) extractor).extract(document, holder);
-                assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
-                results.put(field.getName(), holder.value);
-            }
-            else if (extractor instanceof DateMilliExtractor) {
-                NullableDateMilliHolder holder = new NullableDateMilliHolder();
-                ((DateMilliExtractor) extractor).extract(document, holder);
-                assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
-                results.put(field.getName(), holder.value);
-            }
-            else if (extractor instanceof BitExtractor) {
-                NullableBitHolder holder = new NullableBitHolder();
-                ((BitExtractor) extractor).extract(document, holder);
-                assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
-                results.put(field.getName(), holder.value);
+            Object value = extractValue(extractor, field, document);
+            if (value != null) {
+                results.put(field.getName(), value);
             }
         }
 
         return results;
+    }
+
+    /**
+     * Extracts a value from a document using the appropriate extractor and holder.
+     * @param extractor the extractor to use
+     * @param field the field being extracted
+     * @param document the document containing the data
+     * @return the extracted value, or null if extraction failed
+     * @throws Exception
+     */
+    private Object extractValue(Extractor extractor, Field field, Map<String, Object> document)
+            throws Exception
+    {
+        if (extractor instanceof VarCharExtractor) {
+            NullableVarCharHolder holder = new NullableVarCharHolder();
+            ((VarCharExtractor) extractor).extract(document, holder);
+            assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
+            return holder.value;
+        }
+        else if (extractor instanceof BigIntExtractor) {
+            NullableBigIntHolder holder = new NullableBigIntHolder();
+            ((BigIntExtractor) extractor).extract(document, holder);
+            assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
+            return holder.value;
+        }
+        else if (extractor instanceof IntExtractor) {
+            NullableIntHolder holder = new NullableIntHolder();
+            ((IntExtractor) extractor).extract(document, holder);
+            assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
+            return holder.value;
+        }
+        else if (extractor instanceof SmallIntExtractor) {
+            NullableSmallIntHolder holder = new NullableSmallIntHolder();
+            ((SmallIntExtractor) extractor).extract(document, holder);
+            assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
+            return holder.value;
+        }
+        else if (extractor instanceof TinyIntExtractor) {
+            NullableTinyIntHolder holder = new NullableTinyIntHolder();
+            ((TinyIntExtractor) extractor).extract(document, holder);
+            assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
+            return holder.value;
+        }
+        else if (extractor instanceof Float8Extractor) {
+            NullableFloat8Holder holder = new NullableFloat8Holder();
+            ((Float8Extractor) extractor).extract(document, holder);
+            assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
+            return holder.value;
+        }
+        else if (extractor instanceof Float4Extractor) {
+            NullableFloat4Holder holder = new NullableFloat4Holder();
+            ((Float4Extractor) extractor).extract(document, holder);
+            assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
+            return holder.value;
+        }
+        else if (extractor instanceof DateMilliExtractor) {
+            NullableDateMilliHolder holder = new NullableDateMilliHolder();
+            ((DateMilliExtractor) extractor).extract(document, holder);
+            assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
+            return holder.value;
+        }
+        else if (extractor instanceof BitExtractor) {
+            NullableBitHolder holder = new NullableBitHolder();
+            ((BitExtractor) extractor).extract(document, holder);
+            assertEquals("Could not extract value for: " + field.getName(), 1, holder.isSet);
+            return holder.value;
+        }
+        return null;
+    }
+
+    @Test
+    public void makeDateMilliExtractor_withLocalDateTimeFormat_parsesAndSetsHolder()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mydatestringlist", Types.MinorType.DATEMILLI.getType())
+                .build();
+
+        Map<String, Object> document = new ObjectMapper().readValue(
+                "{\n" +
+                        "  \"mydatestringlist\" : [\n" +
+                        "    \"2020-05-15T06:49:30.123\"\n" +
+                        "  ]\n" +
+                        "}\n", HashMap.class);
+
+        DateMilliExtractor extractor = (DateMilliExtractor) typeUtils.makeExtractor(mapping.getFields().get(0));
+        NullableDateMilliHolder holder = new NullableDateMilliHolder();
+        extractor.extract(document, holder);
+
+        assertEquals("Should parse local date time format", 1, holder.isSet);
+    }
+
+    @Test
+    public void makeDateMilliExtractor_withInvalidDateFormat_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mydatestringlist", Types.MinorType.DATEMILLI.getType())
+                .build();
+
+        Map<String, Object> document = new ObjectMapper().readValue(
+                "{\n" +
+                        "  \"mydatestringlist\" : [\n" +
+                        "    \"invalid-date-format\"\n" +
+                        "  ]\n" +
+                        "}\n", HashMap.class);
+
+        DateMilliExtractor extractor = (DateMilliExtractor) typeUtils.makeExtractor(mapping.getFields().get(0));
+        NullableDateMilliHolder holder = new NullableDateMilliHolder();
+        extractor.extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for invalid date format", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeFactory_withUnsupportedFieldType_throwsAthenaConnectorException()
+    {
+        Field field = new Field("test", FieldType.nullable(Types.MinorType.INTERVALDAY.getType()), null);
+
+        try {
+            typeUtils.makeFactory(field);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException ex) {
+            assertTrue("Exception message should contain is not supported",
+                    ex.getMessage().contains("is not supported"));
+        }
+        catch (Exception e) {
+            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void makeDateMilliExtractor_withZonedDateTime_parsesEpochSecondsAndNanoSeconds()
+            throws Exception
+    {
+        String dateTimeString = "2020-05-15T06:49:30.123456789+05:00";
+        long expectedMillis = java.time.ZonedDateTime.parse(dateTimeString).toInstant().toEpochMilli();
+
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mydate", Types.MinorType.DATEMILLI.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("mydate", dateTimeString);
+
+        Field dateField = mapping.findField("mydate");
+        if (dateField == null) {
+            fail("Field mydate not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(dateField);
+        assertTrue("makeExtractor should return DateMilliExtractor for DATEMILLI field", extractor instanceof DateMilliExtractor);
+
+        NullableDateMilliHolder holder = new NullableDateMilliHolder();
+        ((DateMilliExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should successfully parse ZonedDateTime", 1, holder.isSet);
+        assertEquals("DateMilliHolder value should match parsed epoch millis", expectedMillis, holder.value);
+    }
+
+    @Test
+    public void makeDateMilliExtractor_withInvalidDateTimeFormatInList_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mydate", Types.MinorType.DATEMILLI.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<String> invalidDateList = new ArrayList<>();
+        invalidDateList.add("invalid-date-format-xyz");
+        document.put("mydate", invalidDateList);
+
+        Field dateField = mapping.findField("mydate");
+        if (dateField == null) {
+            fail("Field mydate not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(dateField);
+        NullableDateMilliHolder holder = new NullableDateMilliHolder();
+        ((DateMilliExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 on parse error", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeDateMilliExtractor_withInvalidDateTimeFormatString_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mydate", Types.MinorType.DATEMILLI.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("mydate", "completely-invalid-date-format-xyz-123");
+
+        Field dateField = mapping.findField("mydate");
+        if (dateField == null) {
+            fail("Field mydate not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(dateField);
+        NullableDateMilliHolder holder = new NullableDateMilliHolder();
+        ((DateMilliExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 when both ZonedDateTime and LocalDateTime parsing fail", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeDateMilliExtractor_withNonStringNonNumberNonList_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mydate", Types.MinorType.DATEMILLI.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("mydate", new HashMap<>());
+
+        Field dateField = mapping.findField("mydate");
+        if (dateField == null) {
+            fail("Field mydate not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(dateField);
+        NullableDateMilliHolder holder = new NullableDateMilliHolder();
+        ((DateMilliExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeDateMilliExtractor_withListContainingNonStringNonNumber_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mydate", Types.MinorType.DATEMILLI.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<Object> invalidList = new ArrayList<>();
+        invalidList.add(new HashMap<>());
+        document.put("mydate", invalidList);
+
+        Field dateField = mapping.findField("mydate");
+        if (dateField == null) {
+            fail("Field mydate not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(dateField);
+        NullableDateMilliHolder holder = new NullableDateMilliHolder();
+        ((DateMilliExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported list element type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeBigIntExtractor_withUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mybigint", Types.MinorType.BIGINT.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("mybigint", new HashMap<>());
+
+        Field field = mapping.findField("mybigint");
+        if (field == null) {
+            fail("Field mybigint not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableBigIntHolder holder = new NullableBigIntHolder();
+        ((BigIntExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeScaledFloatExtractor_withListContainingUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField(new Field("myscaled", new FieldType(true, Types.MinorType.BIGINT.getType(), null,
+                        ImmutableMap.of("scaling_factor", "10.0")), null))
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<Object> invalidList = new ArrayList<>();
+        invalidList.add(new Object());
+        document.put("myscaled", invalidList);
+
+        Field field = mapping.findField("myscaled");
+        if (field == null) {
+            fail("Field myscaled not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableBigIntHolder holder = new NullableBigIntHolder();
+        ((BigIntExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported list element type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeScaledFloatExtractor_withListContainingMap_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField(new Field("myscaled", new FieldType(true, Types.MinorType.BIGINT.getType(), null,
+                        ImmutableMap.of("scaling_factor", "10.0")), null))
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<Object> invalidList = new ArrayList<>();
+        invalidList.add(new HashMap<>());
+        document.put("myscaled", invalidList);
+
+        Field field = mapping.findField("myscaled");
+        if (field == null) {
+            fail("Field myscaled not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableBigIntHolder holder = new NullableBigIntHolder();
+        ((BigIntExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported list element type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeBitExtractor_withUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("myboolean", Types.MinorType.BIT.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("myboolean", new HashMap<>());
+
+        Field field = mapping.findField("myboolean");
+        if (field == null) {
+            fail("Field myboolean not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableBitHolder holder = new NullableBitHolder();
+        ((BitExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeBitExtractor_withListContainingUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("myboolean", Types.MinorType.BIT.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<Object> invalidList = new ArrayList<>();
+        invalidList.add(new HashMap<>());
+        document.put("myboolean", invalidList);
+
+        Field field = mapping.findField("myboolean");
+        if (field == null) {
+            fail("Field myboolean not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableBitHolder holder = new NullableBitHolder();
+        ((BitExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported list element type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeVarCharExtractor_withUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mytext", Types.MinorType.VARCHAR.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("mytext", new Object());
+
+        Field field = mapping.findField("mytext");
+        if (field == null) {
+            fail("Field mytext not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableVarCharHolder holder = new NullableVarCharHolder();
+        ((VarCharExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeIntExtractor_withListContainingUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("myinteger", Types.MinorType.INT.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<Object> invalidList = new ArrayList<>();
+        invalidList.add(new HashMap<>());
+        document.put("myinteger", invalidList);
+
+        Field field = mapping.findField("myinteger");
+        if (field == null) {
+            fail("Field myinteger not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableIntHolder holder = new NullableIntHolder();
+        ((IntExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported list element type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeIntExtractor_withUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("myinteger", Types.MinorType.INT.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("myinteger", new HashMap<>());
+
+        Field field = mapping.findField("myinteger");
+        if (field == null) {
+            fail("Field myinteger not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableIntHolder holder = new NullableIntHolder();
+        ((IntExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeSmallIntExtractor_withListContainingUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("myshort", Types.MinorType.SMALLINT.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<Object> invalidList = new ArrayList<>();
+        invalidList.add(new HashMap<>());
+        document.put("myshort", invalidList);
+
+        Field field = mapping.findField("myshort");
+        if (field == null) {
+            fail("Field myshort not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableSmallIntHolder holder = new NullableSmallIntHolder();
+        ((SmallIntExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported list element type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeSmallIntExtractor_withUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("myshort", Types.MinorType.SMALLINT.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("myshort", new HashMap<>());
+
+        Field field = mapping.findField("myshort");
+        if (field == null) {
+            fail("Field myshort not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableSmallIntHolder holder = new NullableSmallIntHolder();
+        ((SmallIntExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeTinyIntExtractor_withListContainingUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mybyte", Types.MinorType.TINYINT.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<Object> invalidList = new ArrayList<>();
+        invalidList.add(new HashMap<>());
+        document.put("mybyte", invalidList);
+
+        Field field = mapping.findField("mybyte");
+        if (field == null) {
+            fail("Field mybyte not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableTinyIntHolder holder = new NullableTinyIntHolder();
+        ((TinyIntExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported list element type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeTinyIntExtractor_withUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mybyte", Types.MinorType.TINYINT.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("mybyte", new HashMap<>());
+
+        Field field = mapping.findField("mybyte");
+        if (field == null) {
+            fail("Field mybyte not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableTinyIntHolder holder = new NullableTinyIntHolder();
+        ((TinyIntExtractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeFloat8Extractor_withListContainingUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mydouble", Types.MinorType.FLOAT8.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<Object> invalidList = new ArrayList<>();
+        invalidList.add(new HashMap<>());
+        document.put("mydouble", invalidList);
+
+        Field field = mapping.findField("mydouble");
+        if (field == null) {
+            fail("Field mydouble not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableFloat8Holder holder = new NullableFloat8Holder();
+        ((Float8Extractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported list element type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeFloat8Extractor_withUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("mydouble", Types.MinorType.FLOAT8.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("mydouble", new HashMap<>());
+
+        Field field = mapping.findField("mydouble");
+        if (field == null) {
+            fail("Field mydouble not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableFloat8Holder holder = new NullableFloat8Holder();
+        ((Float8Extractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeFloat4Extractor_withListContainingUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("myfloat", Types.MinorType.FLOAT4.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        List<Object> invalidList = new ArrayList<>();
+        invalidList.add(new HashMap<>());
+        document.put("myfloat", invalidList);
+
+        Field field = mapping.findField("myfloat");
+        if (field == null) {
+            fail("Field myfloat not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableFloat4Holder holder = new NullableFloat4Holder();
+        ((Float4Extractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported list element type", 0, holder.isSet);
+    }
+
+    @Test
+    public void makeFloat4Extractor_withUnsupportedType_setsIsSetToZero()
+            throws Exception
+    {
+        mapping = SchemaBuilder.newBuilder()
+                .addField("myfloat", Types.MinorType.FLOAT4.getType())
+                .build();
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("myfloat", new HashMap<>());
+
+        Field field = mapping.findField("myfloat");
+        if (field == null) {
+            fail("Field myfloat not found in schema");
+        }
+        Extractor extractor = typeUtils.makeExtractor(field);
+        NullableFloat4Holder holder = new NullableFloat4Holder();
+        ((Float4Extractor) extractor).extract(document, holder);
+
+        assertEquals("Should set isSet to 0 for unsupported type", 0, holder.isSet);
     }
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchTypeUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchTypeUtilsTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.elasticsearch;
 
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.data.writers.extractors.BigIntExtractor;
 import com.amazonaws.athena.connector.lambda.data.writers.extractors.BitExtractor;
 import com.amazonaws.athena.connector.lambda.data.writers.extractors.DateMilliExtractor;
@@ -57,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -613,17 +615,10 @@ public class ElasticsearchTypeUtilsTest
     {
         Field field = new Field("test", FieldType.nullable(Types.MinorType.INTERVALDAY.getType()), null);
 
-        try {
-            typeUtils.makeFactory(field);
-            fail("Expected AthenaConnectorException was not thrown");
-        }
-        catch (com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException ex) {
-            assertTrue("Exception message should contain is not supported",
-                    ex.getMessage().contains("is not supported"));
-        }
-        catch (Exception e) {
-            fail("Expected AthenaConnectorException but got: " + e.getClass().getName());
-        }
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                () -> typeUtils.makeFactory(field));
+        assertTrue("Exception message should contain is not supported",
+                ex.getMessage().contains("is not supported"));
     }
 
     @Test

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/qpt/ElasticsearchQueryPassthroughTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/qpt/ElasticsearchQueryPassthroughTest.java
@@ -1,0 +1,85 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.elasticsearch.qpt;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * This class is used to test the ElasticsearchQueryPassthrough class.
+ */
+public class ElasticsearchQueryPassthroughTest
+{
+    private static final String EXPECTED_SCHEMA_NAME = "system";
+    private static final String EXPECTED_FUNCTION_NAME = "query";
+    private static final String SCHEMA_ARG = "SCHEMA";
+    private static final String INDEX_ARG = "INDEX";
+    private static final String QUERY_ARG = "QUERY";
+
+    private ElasticsearchQueryPassthrough queryPassthrough;
+
+    @Before
+    public void setUp()
+    {
+        queryPassthrough = new ElasticsearchQueryPassthrough();
+    }
+
+    @Test
+    public void getFunctionSchema_returnsSystemSchema()
+    {
+        String schema = queryPassthrough.getFunctionSchema();
+
+        assertEquals("Schema should be 'system'", EXPECTED_SCHEMA_NAME, schema);
+    }
+
+    @Test
+    public void getFunctionName_returnsQueryName()
+    {
+        String functionName = queryPassthrough.getFunctionName();
+
+        assertEquals("Function name should be 'query'", EXPECTED_FUNCTION_NAME, functionName);
+    }
+
+    @Test
+    public void getFunctionArguments_returnsExpectedArguments()
+    {
+        List<String> arguments = queryPassthrough.getFunctionArguments();
+
+        assertNotNull("getFunctionArguments() should not return null", arguments);
+        assertEquals("Should have 3 arguments", 3, arguments.size());
+        assertEquals("First argument should be SCHEMA", SCHEMA_ARG, arguments.get(0));
+        assertEquals("Second argument should be INDEX", INDEX_ARG, arguments.get(1));
+        assertEquals("Third argument should be QUERY", QUERY_ARG, arguments.get(2));
+    }
+
+    @Test
+    public void getLogger_returnsLogger()
+    {
+        Logger logger = queryPassthrough.getLogger();
+
+        assertNotNull("getLogger() should not return null", logger);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across core components with comprehensive unit tests for client factory, metadata handling, field resolution, and query utilities.
  * Refactored existing tests with improved naming conventions and additional edge-case scenarios for better maintainability.

* **Chores**
  * Added testing framework dependency to support advanced mocking capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly adds/expands unit tests, but also updates several dependency versions and changes DataLakeGen2 credential-provider override signatures, which could cause compatibility or runtime issues if the base SDK contracts differ.
> 
> **Overview**
> **Broadly expands test coverage for the Elasticsearch connector** by adding new unit tests for request signing, REST client factories/caching, schema/mapping parsing, domain map resolution, query building, metadata handling (including query passthrough and pagination), and record reading (spill/no-spill and error paths). Existing Elasticsearch tests are also refactored for clearer naming and more edge-case assertions.
> 
> **Updates connector dependencies and a couple of small runtime code paths**: bumps `zookeeper` and `cloudwatchlogs` versions, adds `mockito-inline` for tests, updates Elasticsearch client creation to use `DefaultCredentialsProvider.builder().build()`, and updates DataLakeGen2 handlers to override `createCredentialsProvider(secretName, requestOverrideConfiguration)` instead of the older `getCredentialProvider()` method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24e2bb2e3fd8217b48f09161b03ed82782ab03f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->