### PR TITLE
Dynamodb unit tests

### DIFF
--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
@@ -28,13 +28,15 @@ import com.amazonaws.athena.connector.lambda.data.writers.extractors.VarCharExtr
 import com.amazonaws.athena.connector.lambda.data.writers.holders.NullableDecimalHolder;
 import com.amazonaws.athena.connector.lambda.data.writers.holders.NullableVarBinaryHolder;
 import com.amazonaws.athena.connector.lambda.data.writers.holders.NullableVarCharHolder;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connectors.dynamodb.util.DDBRecordMetadata;
 import com.amazonaws.athena.connectors.dynamodb.util.DDBTypeUtils;
-
 import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.holders.NullableBitHolder;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,18 +45,28 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.arrow.vector.types.pojo.Field;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -62,6 +74,25 @@ import static org.mockito.Mockito.mock;
 public class DDBTypeUtilsTest
 {
     private static final Logger logger = LoggerFactory.getLogger(DDBTypeUtilsTest.class);
+    private static final String TEST_FIELD_NAME = "testField";
+    private static final String TEST_DATE_FIELD = "testDate";
+    private static final String TEST_COLUMN_NAME = "testColumn";
+    private static final String KEY = "key";
+    private static final String VALUE = "value";
+    private static final String TEST_DATA = "test data";
+    private static final String UNKNOWN_TYPE = "UNKNOWN";
+    private static final String UNSUPPORTED = "unsupported";
+    private static final String EXPECTED_KEY = "expectedKey";
+    private static final String TEST_STRING_SET = "testStringSet";
+    private static final String TEST_NUMBER_SET = "testNumberSet";
+    private static final String TEST_BINARY_SET = "testBinarySet";
+    private static final String TEST_LIST = "testList";
+    private static final String TEST_MAP = "testMap";
+    private static final String TEST_BYTES = "testBytes";
+    private static final String TEST_BOOLEAN = "testBoolean";
+    private static final String TEST_STRING = "testString";
+    private static final String TEST_NUMBER = "testNumber";
+    private static final String TEST_BINARY = "testBinary";
 
     private String col1 = "col_1";
     private String col2 = "col_2";
@@ -78,10 +109,10 @@ public class DDBTypeUtilsTest
     }
 
     @Test
-    public void makeDecimalExtractorTest()
+    public void makeExtractor_withDecimalFields_createsDecimalExtractor()
             throws Exception
     {
-        logger.info("makeDecimalExtractorTest - enter");
+        logger.info("makeExtractor_withDecimalFields_returnsDecimalExtractor - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField(col1, ArrowType.Decimal.createDecimal(38, 18, 128))
@@ -100,16 +131,16 @@ public class DDBTypeUtilsTest
                 col1, new BigDecimal(literalValue),
                 col2, new BigDecimal(literalValue2));
         Map<String, Object> extractedResults = testField(mapping, testValue);
-        logger.info("makeDecimalExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeExtractor_withDecimalFields_returnsDecimalExtractor - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
-        logger.info("makeDecimalExtractorTest - exit");
+        logger.info("makeExtractor_withDecimalFields_returnsDecimalExtractor - exit");
     }
 
     @Test
-    public void makeVarBinaryExtractorTest()
+    public void makeExtractor_withVarBinaryFields_createsVarBinaryExtractor()
             throws Exception
     {
-        logger.info("makeVarBinaryExtractorTest - enter");
+        logger.info("makeExtractor_withVarBinaryFields_returnsVarBinaryExtractor - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField(col1, Types.MinorType.VARBINARY.getType())
@@ -138,14 +169,14 @@ public class DDBTypeUtilsTest
         assertEquals("Extracted results are not as expected!",
                 new String(byteValue2),
                 new String((byte[]) extractedResults.get(col2)));
-        logger.info("makeVarBinaryExtractorTest - exit");
+        logger.info("makeExtractor_withVarBinaryFields_returnsVarBinaryExtractor - exit");
     }
 
     @Test
-    public void makeBitExtractorTest()
+    public void makeExtractor_withBitFields_createsBitExtractor()
             throws Exception
     {
-        logger.info("makeBitExtractorTest - enter");
+        logger.info("makeExtractor_withBitFields_returnsBitExtractor - enter");
 
         mapping = SchemaBuilder.newBuilder()
                 .addField(col1, Types.MinorType.BIT.getType())
@@ -165,15 +196,16 @@ public class DDBTypeUtilsTest
                 col1, 1,
                 col2, 0);
         Map<String, Object> extractedResults = testField(mapping, testValue);
-        logger.info("makeBitExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
+        logger.info("makeExtractor_withBitFields_returnsBitExtractor - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
-        logger.info("makeBitExtractorTest - exit");
+        logger.info("makeExtractor_withBitFields_returnsBitExtractor - exit");
     }
     
     @Test
-    public void inferArrowFieldListWithNullTest() throws Exception
+    public void inferArrowField_withListContainingNull_infersListFieldWithVarcharChild()
+            throws Exception
     {
-        java.util.ArrayList inputArray = new java.util.ArrayList<String>();
+        List<String> inputArray = new ArrayList<>();
         inputArray.add("value1");
         inputArray.add(null);
         inputArray.add("value3");
@@ -183,6 +215,537 @@ public class DDBTypeUtilsTest
         assertEquals("Type does not match!", ArrowType.List.INSTANCE, testField.getType());
         assertEquals("Children Length Off!", 1, testField.getChildren().size());
         assertEquals("Wrong Child Type!", ArrowType.Utf8.INSTANCE, testField.getChildren().get(0).getType());
+    }
+
+    @Test
+    public void inferArrowField_withSetOfNumbers_infersListFieldWithDecimalChild()
+    {
+        Set<BigDecimal> numberSet = new HashSet<>();
+        numberSet.add(new BigDecimal("123.45"));
+        numberSet.add(new BigDecimal("678.90"));
+        
+        Field result = DDBTypeUtils.inferArrowField(TEST_NUMBER_SET, DDBTypeUtils.toAttributeValue(numberSet));
+
+        assertField(result, TEST_NUMBER_SET, Types.MinorType.LIST.getType());
+        assertEquals(ArrowType.Decimal.createDecimal(38, 9, 128), result.getChildren().get(0).getType());
+    }
+
+    @Test
+    public void inferArrowField_withSetOfStrings_infersListFieldWithVarcharChild()
+    {
+        Set<String> stringSet = new HashSet<>();
+        stringSet.add("value1");
+        stringSet.add("value2");
+        
+        Field result = DDBTypeUtils.inferArrowField(TEST_STRING_SET, DDBTypeUtils.toAttributeValue(stringSet));
+
+        assertField(result, TEST_STRING_SET, Types.MinorType.LIST.getType());
+        assertEquals(Types.MinorType.VARCHAR.getType(), result.getChildren().get(0).getType());
+    }
+
+    @Test
+    public void inferArrowField_withEmptyList_returnsNull()
+    {
+        AttributeValue value = AttributeValue.builder()
+                .l(Collections.emptyList())
+                .build();
+        
+        Field result = DDBTypeUtils.inferArrowField("testEmptyList", value);
+        // This is the expected behavior for empty lists that can't be inferred
+        assertNull("Result should be null for empty list", result);
+    }
+
+    @Test
+    public void inferArrowField_withBytesType_infersVarBinaryField()
+    {
+        byte[] bytes = TEST_DATA.getBytes();
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        AttributeValue value = AttributeValue.builder().b(SdkBytes.fromByteBuffer(buffer)).build();
+        
+        Field result = DDBTypeUtils.inferArrowField(TEST_BYTES, value);
+
+        assertField(result, TEST_BYTES, Types.MinorType.VARBINARY.getType());
+    }
+
+    @Test
+    public void inferArrowField_withBooleanType_infersBitField()
+    {
+        AttributeValue value = AttributeValue.builder().bool(true).build();
+        
+        Field result = DDBTypeUtils.inferArrowField(TEST_BOOLEAN, value);
+
+        assertField(result, TEST_BOOLEAN, Types.MinorType.BIT.getType());
+    }
+
+    @Test
+    public void inferArrowField_withNullAttributeValue_returnsNull()
+    {
+        // Create an AttributeValue with null to trigger the null return path
+        AttributeValue value = AttributeValue.builder().nul(true).build();
+        Field result = DDBTypeUtils.inferArrowField(TEST_FIELD_NAME, value);
+        assertNull("Result should be null for null attribute value", result);
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withStringType_createsVarcharField()
+    {
+        Field result = DDBTypeUtils.getArrowFieldFromDDBType(TEST_STRING, "S");
+        assertField(result, TEST_STRING, Types.MinorType.VARCHAR.getType());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withNumberType_createsDecimalField()
+    {
+        Field result = DDBTypeUtils.getArrowFieldFromDDBType(TEST_NUMBER, "N");
+        assertEquals("Field name should match", TEST_NUMBER, result.getName());
+        assertEquals("Field type should be Decimal", ArrowType.Decimal.createDecimal(38, 9, 128), result.getType());
+        assertTrue("FieldType should be nullable", result.getFieldType().isNullable());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withBooleanType_createsBitField()
+    {
+        Field result = DDBTypeUtils.getArrowFieldFromDDBType(TEST_BOOLEAN, "BOOL");
+        assertField(result, TEST_BOOLEAN, Types.MinorType.BIT.getType());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withBinaryType_createsVarBinaryField()
+    {
+        Field result = DDBTypeUtils.getArrowFieldFromDDBType(TEST_BINARY, "B");
+        assertField(result, TEST_BINARY, Types.MinorType.VARBINARY.getType());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withStringSetType_createsListFieldWithVarcharChild()
+    {
+        Field result = DDBTypeUtils.getArrowFieldFromDDBType(TEST_STRING_SET, "SS");
+        assertField(result, TEST_STRING_SET, Types.MinorType.LIST.getType());
+        assertEquals("Child type should be VARCHAR", Types.MinorType.VARCHAR.getType(), result.getChildren().get(0).getType());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withNumberSetType_createsListFieldWithDecimalChild()
+    {
+        Field result = DDBTypeUtils.getArrowFieldFromDDBType(TEST_NUMBER_SET, "NS");
+        assertField(result, TEST_NUMBER_SET, Types.MinorType.LIST.getType());
+        assertEquals("Child type should be Decimal", ArrowType.Decimal.createDecimal(38, 9, 128), result.getChildren().get(0).getType());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withBinarySetType_createsListFieldWithVarBinaryChild()
+    {
+        Field result = DDBTypeUtils.getArrowFieldFromDDBType(TEST_BINARY_SET, "BS");
+        assertField(result, TEST_BINARY_SET, Types.MinorType.LIST.getType());
+        assertEquals("Child type should be VARBINARY", Types.MinorType.VARBINARY.getType(), result.getChildren().get(0).getType());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withListType_createsListField()
+    {
+        Field result = DDBTypeUtils.getArrowFieldFromDDBType(TEST_LIST, "L");
+        assertField(result, TEST_LIST, Types.MinorType.LIST.getType());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withMapType_createsStructField()
+    {
+        Field result = DDBTypeUtils.getArrowFieldFromDDBType(TEST_MAP, "M");
+        assertField(result, TEST_MAP, Types.MinorType.STRUCT.getType());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withUnknownType_throwsAthenaConnectorException()
+    {
+        try {
+            DDBTypeUtils.getArrowFieldFromDDBType("testUnknown", UNKNOWN_TYPE);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error about unknown type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+        }
+    }
+
+    @Test
+    public void coerceValueToExpectedType_withBigDecimalToDateMilli_coercesToLocalDateTime()
+    {
+        BigDecimal timestamp = new BigDecimal("1609459200000"); // 2021-01-01 00:00:00 UTC
+        Field field = new Field(TEST_DATE_FIELD, FieldType.nullable(Types.MinorType.DATEMILLI.getType()), null);
+        
+        Object result = DDBTypeUtils.coerceValueToExpectedType(timestamp, field, Types.MinorType.DATEMILLI, 
+                new DDBRecordMetadata(SchemaBuilder.newBuilder().addField(field).build()));
+        
+        assertTrue("Result should be LocalDateTime", result instanceof LocalDateTime);
+        LocalDateTime dateTime = (LocalDateTime) result;
+        assertEquals("Year should be 2021", 2021, dateTime.getYear());
+        assertEquals("Month should be 1", 1, dateTime.getMonthValue());
+        assertEquals("Day should be 1", 1, dateTime.getDayOfMonth());
+    }
+
+    @Test
+    public void coerceValueToExpectedType_withBigDecimalToDateDay_coercesToLocalDate()
+    {
+        BigDecimal days = new BigDecimal("18628");
+        Field field = new Field(TEST_DATE_FIELD, FieldType.nullable(Types.MinorType.DATEDAY.getType()), null);
+        DDBRecordMetadata metadata = new DDBRecordMetadata(SchemaBuilder.newBuilder()
+                .addField(TEST_DATE_FIELD, Types.MinorType.DATEDAY.getType())
+                .build());
+        
+        Object result = DDBTypeUtils.coerceValueToExpectedType(days, field, Types.MinorType.DATEDAY, metadata);
+        
+        assertNotNull("Result should not be null", result);
+        assertTrue("Result should be LocalDate", result instanceof LocalDate);
+    }
+
+    @Test
+    public void coerceValueToExpectedType_withBigDecimalToFloat8_coercesToDouble()
+    {
+        BigDecimal value = new BigDecimal("123.45");
+        Field field = new Field("testNumber", FieldType.nullable(Types.MinorType.FLOAT8.getType()), null);
+        DDBRecordMetadata metadata = new DDBRecordMetadata(SchemaBuilder.newBuilder()
+                .addField("testNumber", Types.MinorType.FLOAT8.getType())
+                .build());
+        
+        Object result = DDBTypeUtils.coerceValueToExpectedType(value, field, Types.MinorType.FLOAT8, metadata);
+        
+        assertNotNull("Result should not be null", result);
+        // The coercion should convert BigDecimal to Double for FLOAT8 type
+        assertTrue("Result should be Double for FLOAT8 type", result instanceof Double);
+        assertEquals("Double value should match BigDecimal value", value.doubleValue(), (Double) result, 0.001);
+    }
+
+    @Test
+    public void coerceValueToExpectedType_withInvalidTimestamp_coercesToLocalDateTimeWithDefaultValues()
+    {
+        BigDecimal invalidValue = new BigDecimal("-1");
+        Field field = new Field(TEST_DATE_FIELD, FieldType.nullable(Types.MinorType.DATEMILLI.getType()), null);
+        DDBRecordMetadata metadata = new DDBRecordMetadata(SchemaBuilder.newBuilder()
+                .addField(TEST_DATE_FIELD, Types.MinorType.DATEMILLI.getType())
+                .build());
+        
+        Object result = DDBTypeUtils.coerceValueToExpectedType(invalidValue, field, Types.MinorType.DATEMILLI, metadata);
+        
+        assertTrue("Result should be LocalDateTime", result instanceof LocalDateTime);
+        LocalDateTime dateTime = (LocalDateTime) result;
+        assertEquals("Year should be 1969 for invalid timestamp", 1969, dateTime.getYear());
+        assertEquals("Month should be 12 for invalid timestamp", 12, dateTime.getMonthValue());
+        assertEquals("Day should be 31 for invalid timestamp", 31, dateTime.getDayOfMonth());
+        assertEquals("Hour should be 23 for invalid timestamp", 23, dateTime.getHour());
+        assertEquals("Minute should be 59 for invalid timestamp", 59, dateTime.getMinute());
+        assertEquals("Second should be 59 for invalid timestamp", 59, dateTime.getSecond());
+        assertEquals("Nano should be 999000000 for invalid timestamp", 999, dateTime.getNano() / 1_000_000);
+    }
+
+    @Test
+    public void convertArrowTypeIfNecessary_withLocalDateTimeAndFormat_formatsAsString()
+    {
+        LocalDateTime dateTime = LocalDateTime.of(2021, 1, 1, 12, 30, 45);
+        
+        // Create schema with custom metadata for timezone and format
+        Map<String, String> customMetadata = new HashMap<>();
+        customMetadata.put("defaultTimeZone", "UTC");
+        customMetadata.put("datetimeFormatMappingNormalized", TEST_COLUMN_NAME + "=" + "yyyy-MM-dd HH:mm:ss");
+        
+        Schema schemaWithMetadata = new Schema(Collections.emptyList(), customMetadata);
+        DDBRecordMetadata metadata = new DDBRecordMetadata(schemaWithMetadata);
+        
+        Object result = DDBTypeUtils.convertArrowTypeIfNecessary(TEST_COLUMN_NAME, dateTime, metadata);
+        
+        assertTrue("Result should be String", result instanceof String);
+        assertEquals("Formatted date time string should match expected format", "2021-01-01 12:30:45", result);
+    }
+
+    @Test
+    public void coerceValueToExpectedType_withBigDecimalToVarchar_returnsOriginalValue()
+    {
+        BigDecimal value = new BigDecimal("123456789");
+        Field field = new Field(TEST_FIELD_NAME, FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+        DDBRecordMetadata metadata = new DDBRecordMetadata(new Schema(Collections.singletonList(field)));
+        
+        Object result = DDBTypeUtils.coerceValueToExpectedType(value, field, Types.MinorType.VARCHAR, metadata);
+        
+        assertEquals("Value should pass through unchanged for VARCHAR field", value, result);
+    }
+
+    @Test
+    public void coerceValueToExpectedType_withVarcharField_returnsOriginalValue()
+    {
+        // VARCHAR fields don't trigger coercion, value passes through unchanged
+        BigDecimal value = new BigDecimal("12345");
+        Field field = new Field(TEST_FIELD_NAME, FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+        DDBRecordMetadata metadata = new DDBRecordMetadata(new Schema(Collections.singletonList(field)));
+        
+        Object result = DDBTypeUtils.coerceValueToExpectedType(value, field, Types.MinorType.VARCHAR, metadata);
+        
+        assertEquals("Value should pass through unchanged for VARCHAR field", value, result);
+    }
+
+    @Test
+    public void coerceListToExpectedType_withMapInsteadOfList_throwsAthenaConnectorException()
+    {
+        try {
+            Map<String, String> mapValue = new HashMap<>();
+            mapValue.put(KEY, VALUE);
+            
+            Field childField = new Field("child", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+            Field field = new Field(TEST_LIST, FieldType.nullable(Types.MinorType.LIST.getType()), Collections.singletonList(childField));
+            DDBRecordMetadata metadata = new DDBRecordMetadata(new Schema(Collections.singletonList(field)));
+            
+            DDBTypeUtils.coerceListToExpectedType(mapValue, field, metadata);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error about map instead of list",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+        }
+    }
+
+    @Test
+    public void makeExtractor_withCaseInsensitive_createsExtractor()
+    {
+        Field field = new Field("TestField", FieldType.nullable(ArrowType.Decimal.createDecimal(38, 9, 128)), null);
+        DDBRecordMetadata metadata = new DDBRecordMetadata(new Schema(Collections.singletonList(field)));
+        
+        Optional<Extractor> extractor = DDBTypeUtils.makeExtractor(field, metadata, true);
+        
+        assertTrue("Extractor should be present", extractor.isPresent());
+    }
+
+    @Test
+    public void toAttributeValue_withBigDecimal_createsAttributeValueWithNumber()
+    {
+        BigDecimal value = new BigDecimal("123.456");
+        
+        AttributeValue result = DDBTypeUtils.toAttributeValue(value);
+        
+        assertNotNull("Result should not be null", result);
+        assertEquals("Attribute value number should match", "123.456", result.n());
+    }
+
+    @Test
+    public void toAttributeValue_withByteArray_createsAttributeValueWithBinary()
+    {
+        byte[] bytes = TEST_DATA.getBytes();
+        
+        AttributeValue result = DDBTypeUtils.toAttributeValue(bytes);
+        
+        assertNotNull("Result should not be null", result);
+        assertNotNull("Result should have binary value", result.b());
+    }
+
+    @Test
+    public void toAttributeValue_withByteBuffer_createsAttributeValueWithBinary()
+    {
+        ByteBuffer buffer = ByteBuffer.wrap(TEST_DATA.getBytes());
+        
+        AttributeValue result = DDBTypeUtils.toAttributeValue(buffer);
+        
+        assertNotNull("Result should not be null", result);
+        assertNotNull("Result should have binary value", result.b());
+    }
+
+    @Test
+    public void toAttributeValue_withUnsupportedType_throwsAthenaConnectorException()
+    {
+        try {
+            Object unsupportedValue = new StringBuilder(UNSUPPORTED);
+            DDBTypeUtils.toAttributeValue(unsupportedValue);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error about unsupported type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+        }
+    }
+
+    @Test
+    public void jsonToAttributeValue_withUnknownKey_throwsAthenaConnectorException()
+    {
+        try {
+            String json = "{\"wrongKey\": \"" + VALUE + "\"}";
+            DDBTypeUtils.jsonToAttributeValue(json, EXPECTED_KEY);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error about unknown key",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+        }
+    }
+
+    @Test
+    public void toAttributeValue_withUnsupportedSetType_throwsAthenaConnectorException()
+    {
+        try {
+            Set<Object> unsupportedSet = new HashSet<>();
+            unsupportedSet.add(new StringBuilder(UNSUPPORTED));
+            
+            DDBTypeUtils.toAttributeValue(unsupportedSet);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error about unsupported set type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+        }
+    }
+
+    @Test
+    public void makeExtractor_withUnsupportedFieldType_returnsEmptyOptional()
+    {
+        Field unsupportedField = new Field("unsupported", FieldType.nullable(Types.MinorType.INTERVALDAY.getType()), null);
+        DDBRecordMetadata metadata = new DDBRecordMetadata(new Schema(Collections.singletonList(unsupportedField)));
+        
+        Optional<Extractor> extractor = DDBTypeUtils.makeExtractor(unsupportedField, metadata, false);
+        
+        assertFalse("Extractor should not be present for unsupported field type", extractor.isPresent());
+    }
+
+    @Test
+    public void inferArrowField_withEmptyMap_infersVarcharField()
+    {
+        AttributeValue emptyMap = AttributeValue.builder().m(Collections.emptyMap()).build();
+        Field result = DDBTypeUtils.inferArrowField(TEST_MAP, emptyMap);
+        assertNotNull("Result should not be null", result);
+        assertEquals("Empty map should return VARCHAR type", Types.MinorType.VARCHAR.getType(), result.getType());
+    }
+
+    @Test
+    public void inferArrowField_withListContainingMixedTypes_infersListFieldWithVarcharChild()
+    {
+        List<AttributeValue> mixedList = new ArrayList<>();
+        mixedList.add(AttributeValue.builder().s("string").build());
+        mixedList.add(AttributeValue.builder().n("123").build());
+        
+        AttributeValue listValue = AttributeValue.builder().l(mixedList).build();
+        Field result = DDBTypeUtils.inferArrowField(TEST_LIST, listValue);
+        
+        assertNotNull("Result should not be null", result);
+        assertEquals("List with mixed types should return LIST type", Types.MinorType.LIST.getType(), result.getType());
+        assertEquals("Child type should be VARCHAR for mixed types", Types.MinorType.VARCHAR.getType(), result.getChildren().get(0).getType());
+    }
+
+    @Test
+    public void getArrowFieldFromDDBType_withEmptyAttributeType_throwsAthenaConnectorException()
+    {
+        try {
+            DDBTypeUtils.getArrowFieldFromDDBType(TEST_STRING, "");
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error about unknown type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+        }
+    }
+
+    @Test
+    public void toAttributeValue_withNullValue_createsNullAttributeValue()
+    {
+        AttributeValue result = DDBTypeUtils.toAttributeValue(null);
+        assertNotNull("Result should not be null", result);
+        assertTrue("Result should be null attribute", result.nul());
+    }
+
+    @Test
+    public void toAttributeValue_withUnsupportedListType_throwsAthenaConnectorException()
+    {
+        try {
+            List<Object> unsupportedList = new ArrayList<>();
+            unsupportedList.add(new StringBuilder(UNSUPPORTED));
+            
+            DDBTypeUtils.toAttributeValue(unsupportedList);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error about unsupported type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+        }
+    }
+
+    @Test
+    public void toAttributeValue_withUnsupportedMapType_throwsAthenaConnectorException()
+    {
+        try {
+            Map<String, Object> unsupportedMap = new HashMap<>();
+            unsupportedMap.put("key", new StringBuilder(UNSUPPORTED));
+            
+            DDBTypeUtils.toAttributeValue(unsupportedMap);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error about unsupported type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+        }
+    }
+
+    @Test
+    public void coerceValueToExpectedType_withNullValue_returnsNull()
+    {
+        Field field = new Field(TEST_FIELD_NAME, FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+        DDBRecordMetadata metadata = new DDBRecordMetadata(new Schema(Collections.singletonList(field)));
+        
+        Object result = DDBTypeUtils.coerceValueToExpectedType(null, field, Types.MinorType.VARCHAR, metadata);
+        
+        assertNull("Result should be null for null input", result);
+    }
+
+    @Test
+    public void coerceValueToExpectedType_withNullField_returnsOriginalValue()
+    {
+        BigDecimal value = new BigDecimal("123.45");
+        DDBRecordMetadata metadata = new DDBRecordMetadata(new Schema(Collections.emptyList()));
+        
+        Object result = DDBTypeUtils.coerceValueToExpectedType(value, null, Types.MinorType.VARCHAR, metadata);
+        
+        assertEquals("Result should be original value when field is null", value, result);
+    }
+
+    @Test
+    public void convertArrowTypeIfNecessary_withNullObject_returnsNull()
+    {
+        DDBRecordMetadata metadata = new DDBRecordMetadata(new Schema(Collections.emptyList()));
+        
+        Object result = DDBTypeUtils.convertArrowTypeIfNecessary(TEST_COLUMN_NAME, null, metadata);
+        
+        assertNull("Result should be null for null input", result);
+    }
+
+    @Test
+    public void convertArrowTypeIfNecessary_withUnsupportedType_returnsOriginalObject()
+    {
+        Object unsupportedObject = new StringBuilder("test");
+        DDBRecordMetadata metadata = new DDBRecordMetadata(new Schema(Collections.emptyList()));
+        
+        Object result = DDBTypeUtils.convertArrowTypeIfNecessary(TEST_COLUMN_NAME, unsupportedObject, metadata);
+        
+        assertEquals("Result should be original object for unsupported type", unsupportedObject, result);
+    }
+
+    @Test
+    public void jsonToAttributeValue_withInvalidJson_throwsException()
+    {
+        try {
+            String invalidJson = "{invalid json}";
+            DDBTypeUtils.jsonToAttributeValue(invalidJson, EXPECTED_KEY);
+            fail("Expected exception was not thrown");
+        }
+        catch (Exception ex) {
+            // Could be JsonParseException wrapped in AthenaConnectorException or RuntimeException
+            assertTrue("Exception should be thrown for invalid JSON",
+                    ex != null && (ex instanceof AthenaConnectorException || ex.getCause() != null));
+        }
+    }
+
+    @Test
+    public void jsonToAttributeValue_withEmptyJson_throwsAthenaConnectorException()
+    {
+        try {
+            DDBTypeUtils.jsonToAttributeValue("{}", EXPECTED_KEY);
+            fail("Expected AthenaConnectorException was not thrown");
+        }
+        catch (AthenaConnectorException ex) {
+            assertTrue("Exception message should contain error about missing key",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+        }
     }
 
     private Map<String, Object> testField(Schema mapping, Map<String, AttributeValue> values)
@@ -225,5 +788,13 @@ public class DDBTypeUtilsTest
             }
         }
         return results;
+    }
+
+    private void assertField(Field result, String expectedName, ArrowType expectedType)
+    {
+        assertNotNull("Result should not be null", result);
+        assertEquals("Field name should match", expectedName, result.getName());
+        assertEquals("Field type should match", expectedType, result.getType());
+        assertTrue("FieldType should be nullable", result.getFieldType().isNullable());
     }
 }

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
@@ -102,9 +102,7 @@ public class DDBTypeUtilsTest
     private DDBRecordMetadata ddbRecordMetadata;
 
     @Before
-    public void setUp()
-            throws IOException
-    {
+    public void setUp() {
         ddbRecordMetadata = mock(DDBRecordMetadata.class);
     }
 
@@ -202,9 +200,7 @@ public class DDBTypeUtilsTest
     }
     
     @Test
-    public void inferArrowField_withListContainingNull_infersListFieldWithVarcharChild()
-            throws Exception
-    {
+    public void inferArrowField_withListContainingNull_infersListFieldWithVarcharChild() {
         List<String> inputArray = new ArrayList<>();
         inputArray.add("value1");
         inputArray.add(null);
@@ -363,7 +359,7 @@ public class DDBTypeUtilsTest
         }
         catch (AthenaConnectorException ex) {
             assertTrue("Exception message should contain error about unknown type",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Unknown type["));
         }
     }
 
@@ -497,7 +493,7 @@ public class DDBTypeUtilsTest
         }
         catch (AthenaConnectorException ex) {
             assertTrue("Exception message should contain error about map instead of list",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Unexpected type (Map) encountered for:"));
         }
     }
 
@@ -554,8 +550,8 @@ public class DDBTypeUtilsTest
             fail("Expected AthenaConnectorException was not thrown");
         }
         catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain error about unsupported type",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+            assertTrue("Exception message should contain error about unsupported value type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Unsupported value type:"));
         }
     }
 
@@ -568,8 +564,8 @@ public class DDBTypeUtilsTest
             fail("Expected AthenaConnectorException was not thrown");
         }
         catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain error about unknown key",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+            assertTrue("Exception message should contain error about unknown attribute key",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Unknown attribute Key"));
         }
     }
 
@@ -584,8 +580,8 @@ public class DDBTypeUtilsTest
             fail("Expected AthenaConnectorException was not thrown");
         }
         catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain error about unsupported set type",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+            assertTrue("Exception message should contain error about unsupported set element type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Unsupported Set element type:"));
         }
     }
 
@@ -633,7 +629,7 @@ public class DDBTypeUtilsTest
         }
         catch (AthenaConnectorException ex) {
             assertTrue("Exception message should contain error about unknown type",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Unknown type["));
         }
     }
 
@@ -656,8 +652,8 @@ public class DDBTypeUtilsTest
             fail("Expected AthenaConnectorException was not thrown");
         }
         catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain error about unsupported type",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+            assertTrue("Exception message should contain error about unsupported value type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Unsupported value type:"));
         }
     }
 
@@ -672,8 +668,8 @@ public class DDBTypeUtilsTest
             fail("Expected AthenaConnectorException was not thrown");
         }
         catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain error about unsupported type",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+            assertTrue("Exception message should contain error about unsupported value type",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Unsupported value type:"));
         }
     }
 
@@ -726,12 +722,12 @@ public class DDBTypeUtilsTest
         try {
             String invalidJson = "{invalid json}";
             DDBTypeUtils.jsonToAttributeValue(invalidJson, EXPECTED_KEY);
-            fail("Expected exception was not thrown");
+            fail("Expected UncheckedIOException was not thrown");
         }
-        catch (Exception ex) {
-            // Could be JsonParseException wrapped in AthenaConnectorException or RuntimeException
-            assertTrue("Exception should be thrown for invalid JSON",
-                    ex != null && (ex instanceof AthenaConnectorException || ex.getCause() != null));
+        catch (UncheckedIOException ex) {
+            assertTrue("Exception message should indicate JSON parse failure",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty()
+                            && ex.getMessage().contains("JsonParseException"));
         }
     }
 
@@ -743,8 +739,8 @@ public class DDBTypeUtilsTest
             fail("Expected AthenaConnectorException was not thrown");
         }
         catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain error about missing key",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+            assertTrue("Exception message should contain error about missing attribute key",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Unknown attribute Key"));
         }
     }
 

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
@@ -357,8 +357,9 @@ public class DynamoDBMetadataHandlerTest
             fail("Expected AthenaConnectorException was not thrown");
         }
         catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should not be null or empty",
-                    ex.getMessage() != null && !ex.getMessage().isEmpty());
+            assertTrue("Exception message should contain error about non-existent table",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty()
+                            && ex.getMessage().contains("non-existent table"));
         }
     }
 
@@ -373,7 +374,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 new TableName(DEFAULT_SCHEMA, "test_table2"), // Different case from Test_table2
-                new Constraints(new HashMap<>(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(ImmutableMap.of(), Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.emptySet());
 
@@ -395,7 +396,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 new TableName(TEST_CATALOG_NAME, TEST_TABLE),
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET);
         GetTableLayoutResponse res = handler.doGetTableLayout(allocator, req);
@@ -435,7 +436,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 new TableName(TEST_CATALOG_NAME, TEST_TABLE),
-                new Constraints(null, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), queryPlan),
+                getConstraints(null, Collections.emptyMap(), queryPlan),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET);
         GetTableLayoutResponse res = handler.doGetTableLayout(allocator, req);
@@ -469,7 +470,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(null, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), queryPlan),
+                getConstraints(null, Collections.emptyMap(), queryPlan),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
 
@@ -510,7 +511,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
 
@@ -542,7 +543,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                    new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
             // Verify that only the upper bound is present
@@ -559,7 +560,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
             // Verify that both bounds are present for col_6 which is not a sort key
@@ -575,7 +576,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
             // Verify that only the upper bound is present
@@ -592,7 +593,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
             // Verify that both bounds are present for col_6 which is not a sort key
@@ -609,7 +610,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
             assertThat(res2.getPartitions().getSchema().getCustomMetadata().get(RANGE_KEY_FILTER_METADATA), equalTo("(#col_5 > :v0)"));
@@ -623,7 +624,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
             assertThat(res2.getPartitions().getSchema().getCustomMetadata().get(RANGE_KEY_FILTER_METADATA), equalTo("(#col_5 >= :v0)"));
@@ -637,7 +638,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
             assertThat(res2.getPartitions().getSchema().getCustomMetadata().get(RANGE_KEY_FILTER_METADATA), equalTo("(#col_5 < :v0)"));
@@ -651,7 +652,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
             assertThat(res2.getPartitions().getSchema().getCustomMetadata().get(RANGE_KEY_FILTER_METADATA), equalTo("(#col_5 <= :v0)"));
@@ -666,18 +667,14 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(ImmutableMap.of(), Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
 
-        GetSplitsRequest req = new GetSplitsRequest(TEST_IDENTITY,
-                TEST_QUERY_ID,
-                TEST_CATALOG_NAME,
-                TEST_TABLE_NAME,
+        GetSplitsRequest req = getSplitsRequest(
                 layoutResponse.getPartitions(),
                 ImmutableList.of(),
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                null);
+                getConstraints(ImmutableMap.of(), Collections.emptyMap(), null));
         logger.info("doGetSplits: req[{}]", req);
 
         MetadataResponse rawResponse = handler.doGetSplits(allocator, req);
@@ -710,18 +707,14 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 TEST_TABLE_NAME,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 SchemaBuilder.newBuilder().build(),
                 Collections.EMPTY_SET));
 
-        GetSplitsRequest req = new GetSplitsRequest(TEST_IDENTITY,
-                TEST_QUERY_ID,
-                TEST_CATALOG_NAME,
-                TEST_TABLE_NAME,
+        GetSplitsRequest req = getSplitsRequest(
                 layoutResponse.getPartitions(),
                 ImmutableList.of("col_0"),
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                null);
+                getConstraints(constraintsMap, Collections.emptyMap(), null));
         logger.info("doGetSplits: req[{}]", req);
 
         GetSplitsResponse response = handler.doGetSplits(allocator, req);
@@ -777,7 +770,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 tableName,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(ImmutableMap.of(), Collections.emptyMap(), null),
                 getTableResponse.getSchema(),
                 Collections.EMPTY_SET);
 
@@ -827,7 +820,7 @@ public class DynamoDBMetadataHandlerTest
                 TEST_QUERY_ID,
                 TEST_CATALOG_NAME,
                 tableName,
-                new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                getConstraints(constraintsMap, Collections.emptyMap(), null),
                 getTableResponse.getSchema(),
                 Collections.EMPTY_SET);
 
@@ -928,8 +921,8 @@ public class DynamoDBMetadataHandlerTest
             fail("Expected AthenaConnectorException was not thrown");
         }
         catch (AthenaConnectorException ex) {
-            assertTrue("Exception message should contain error about missing passthrough",
-                    ex.getMessage() != null && ex.getMessage().contains("No Query passed through"));
+            assertTrue("Exception message should contain error about missing query passthrough",
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("No Query passed through"));
         }
     }
 
@@ -945,28 +938,14 @@ public class DynamoDBMetadataHandlerTest
                 .addField(COL_0, Types.MinorType.VARCHAR.getType())
                 .build();
 
-        // Create constraints with QPT arguments
-        Constraints constraints = new Constraints(
-            new HashMap<>(),
-            Collections.emptyList(),
-            Collections.emptyList(),
-            DEFAULT_NO_LIMIT,
-            qptArgs, // queryPassthroughArguments
-            null
-        );
-
-        // Create GetSplitsRequest
-        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(TEST_IDENTITY,
-                TEST_QUERY_ID,
-                TEST_CATALOG_NAME,
-                TEST_TABLE_NAME,
-                allocator.createBlock(schema),
+        Block partitions = allocator.createBlock(schema);
+        GetSplitsRequest splitsRequest = getSplitsRequest(
+                partitions,
                 Collections.emptyList(),
-                constraints,
-                null);
+                getConstraints(Collections.emptyMap(), qptArgs, null));
 
         // Get splits response
-        GetSplitsResponse response = handler.doGetSplits(allocator, getSplitsRequest);
+        GetSplitsResponse response = handler.doGetSplits(allocator, splitsRequest);
 
         // Verify we get exactly one split for QPT
         assertNotNull("Response should not be null", response);
@@ -1022,22 +1001,13 @@ public class DynamoDBMetadataHandlerTest
     public void doGetSplits_withMissingPartitionTypeMetadata_throwsAthenaConnectorException()
     {
         try {
-            // Create a schema without partition type metadata
-            Schema schema = SchemaBuilder.newBuilder()
-                    .addField(TEST_FIELD, Types.MinorType.VARCHAR.getType())
-                    .build();
-
+            Schema schema = getSchema();
             Block partitions = allocator.createBlock(schema);
             partitions.setRowCount(1);
-
-            GetSplitsRequest request = new GetSplitsRequest(TEST_IDENTITY,
-                    TEST_QUERY_ID,
-                    TEST_CATALOG_NAME,
-                    TEST_TABLE_NAME,
+            GetSplitsRequest request = getSplitsRequest(
                     partitions,
                     ImmutableList.of(),
-                    new Constraints(ImmutableMap.of(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                    null);
+                    getConstraints(ImmutableMap.of(), Collections.emptyMap(), null));
 
             // This should throw AthenaConnectorException
             handler.doGetSplits(allocator, request);
@@ -1045,7 +1015,7 @@ public class DynamoDBMetadataHandlerTest
         }
         catch (AthenaConnectorException ex) {
             assertTrue("Exception message should contain error about missing partition type metadata",
-                    ex.getMessage() != null && ex.getMessage().contains(PARTITION_TYPE_METADATA));
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains(PARTITION_TYPE_METADATA));
         }
     }
 
@@ -1053,23 +1023,13 @@ public class DynamoDBMetadataHandlerTest
     public void doGetSplits_withInvalidPartitionType_throwsAthenaConnectorException()
     {
         try {
-            // Create a schema with invalid partition type
-            Schema schema = SchemaBuilder.newBuilder()
-                    .addField(TEST_FIELD, Types.MinorType.VARCHAR.getType())
-                    .addMetadata(PARTITION_TYPE_METADATA, "INVALID_TYPE")
-                    .build();
-
+            Schema schema = getSchemaWithPartitionType();
             Block partitions = allocator.createBlock(schema);
             partitions.setRowCount(1);
-
-            GetSplitsRequest request = new GetSplitsRequest(TEST_IDENTITY,
-                    TEST_QUERY_ID,
-                    TEST_CATALOG_NAME,
-                    TEST_TABLE_NAME,
+            GetSplitsRequest request = getSplitsRequest(
                     partitions,
                     ImmutableList.of(),
-                    new Constraints(ImmutableMap.of(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                    null);
+                    getConstraints(ImmutableMap.of(), Collections.emptyMap(), null));
 
             // This should throw AthenaConnectorException
             handler.doGetSplits(allocator, request);
@@ -1080,6 +1040,47 @@ public class DynamoDBMetadataHandlerTest
                     ex.getMessage() != null && (ex.getMessage().contains("INVALID_TYPE") || 
                                                  ex.getMessage().contains("partition")));
         }
+    }
+
+    private static Constraints getConstraints(
+            Map<String, ValueSet> summary,
+            Map<String, String> queryPassthroughArguments,
+            QueryPlan queryPlan)
+    {
+        return new Constraints(
+                summary,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                DEFAULT_NO_LIMIT,
+                queryPassthroughArguments,
+                queryPlan);
+    }
+
+    private Schema getSchema()
+    {
+        return SchemaBuilder.newBuilder()
+                .addField(TEST_FIELD, Types.MinorType.VARCHAR.getType())
+                .build();
+    }
+
+    private Schema getSchemaWithPartitionType()
+    {
+        return SchemaBuilder.newBuilder()
+                .addField(TEST_FIELD, Types.MinorType.VARCHAR.getType())
+                .addMetadata(PARTITION_TYPE_METADATA, "INVALID_TYPE")
+                .build();
+    }
+
+    private GetSplitsRequest getSplitsRequest(Block partitions, List<String> partitionCols, Constraints splitConstraints)
+    {
+        return new GetSplitsRequest(TEST_IDENTITY,
+                TEST_QUERY_ID,
+                TEST_CATALOG_NAME,
+                TEST_TABLE_NAME,
+                partitions,
+                partitionCols,
+                splitConstraints,
+                null);
     }
 
 }

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
@@ -39,8 +39,8 @@ import com.amazonaws.athena.connector.lambda.records.ReadRecordsResponse;
 import com.amazonaws.athena.connector.lambda.records.RecordResponse;
 import com.amazonaws.athena.connector.lambda.security.EncryptionKeyFactory;
 import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
+import com.amazonaws.athena.connectors.dynamodb.qpt.DDBQueryPassthrough;
 import com.amazonaws.athena.connectors.dynamodb.util.DDBTypeUtils;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -50,7 +50,6 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.JsonStringHashMap;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -95,12 +94,12 @@ import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstan
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.SEGMENT_COUNT_METADATA;
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.SEGMENT_ID_PROPERTY;
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.TABLE_METADATA;
-
-import static com.amazonaws.services.dynamodbv2.document.ItemUtils.toAttributeValue;
 import static com.amazonaws.util.json.Jackson.toJsonString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -110,6 +109,15 @@ public class DynamoDBRecordHandlerTest
         extends TestBase
 {
     private static final Logger logger = LoggerFactory.getLogger(DynamoDBRecordHandlerTest.class);
+    private static final String SCHEMA_FUNCTION_NAME = "system.query";
+    private static final String SELECT_COL_0_COL_1_QUERY = "SELECT col_0, col_1 FROM " + TEST_TABLE + " WHERE col_0 = 'test_str_0'";
+    private static final String COL_0 = "col_0";
+    private static final String COL_1 = "col_1";
+    private static final String TEST_STR_0 = "test_str_0";
+    private static final long SPILL_SIZE = 100_000_000_000L;
+    private static final int VALUE_1 = 1;
+    private static final int VALUE_2 = 2;
+    private static final int VALUE_3 = 3;
 
     private static final SpillLocation SPILL_LOCATION = S3SpillLocation.newBuilder()
             .withBucket(UUID.randomUUID().toString())
@@ -153,31 +161,20 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testReadScanSplit()
+    public void doReadRecords_withScanSplit_readsAllRecords()
             throws Exception
     {
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(),null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testReadScanSplit: rows[{}]", response.getRecordCount());
 
         assertEquals(1000, response.getRecords().getRowCount());
@@ -185,7 +182,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testReadScanSplitWithLimitFromQueryPlan()
+    public void doReadRecords_withScanSplitAndLimitFromQueryPlan_readsLimitedRecords()
             throws Exception
     {
         //SELECT * FROM test_table limit 100
@@ -196,11 +193,7 @@ public class DynamoDBRecordHandlerTest
                 "yIAGgoSCAoEEgIIBCIAGgoSCAoEEgIIBSIAGgoSCAoEEgIIBiIAGgoSCAoEEgIIByIAGgoSCAoEEgIICCIAGgoSCAoEEgIICSIAGA" +
                 "AgZBIFY29sXzASBWNvbF8xEgVjb2xfMhIFY29sXzMSBWNvbF80EgVjb2xfNRIFY29sXzYSBWNvbF83EgVjb2xfOBIFY29sXzk=");
 
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE);
 
         ReadRecordsRequest request = new ReadRecordsRequest(
                 TEST_IDENTITY,
@@ -209,16 +202,13 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(),
-                        Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(),queryPlan),
+                constraintsWithQueryPlan(queryPlan),
                 100_000_000_000L, // too big to spill
                 100_000_000_000L);
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testReadScanSplit: rows[{}]", response.getRecordCount());
 
         assertEquals(100, response.getRecords().getRowCount());
@@ -226,7 +216,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testReadScanSplitWithLimitAndOrderByFromQueryPlan()
+    public void doReadRecords_withScanSplitLimitAndOrderBy_readsAllRecords()
             throws Exception
     {
         //SELECT * FROM test_table order by col_0 limit 100
@@ -238,11 +228,7 @@ public class DynamoDBRecordHandlerTest
                 "CCAkiABoMCggSBgoCEgAiABACGAAgZBIFY29sXzASBWNvbF8xEgVjb2xfMhIFY29sXzMSBWNvbF80EgVjb2xfNRIFY29sXzYSBWNvbF8" +
                 "3EgVjb2xfOBIFY29sXzk=");
 
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE);
 
         ReadRecordsRequest request = new ReadRecordsRequest(
                 TEST_IDENTITY,
@@ -251,16 +237,13 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(),
-                        Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(),queryPlan),
+                constraintsWithQueryPlan(queryPlan),
                 100_000_000_000L, // too big to spill
                 100_000_000_000L);
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testReadScanSplit: rows[{}]", response.getRecordCount());
 
         assertEquals(1000, response.getRecords().getRowCount());
@@ -268,31 +251,20 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testReadScanSplitWithLimit()
+    public void doReadRecords_withScanSplitAndLimit_readsLimitedRecords()
         throws Exception
     {
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                new Constraints(ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), 5, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                constraintsWithLimit(5));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testReadScanSplit: rows[{}]", response.getRecordCount());
 
         assertEquals(5, response.getRecords().getRowCount());
@@ -300,31 +272,20 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testReadScanSplitWithLimitLargerThanN()
+    public void doReadRecords_withScanSplitAndLimitLargerThanRecords_readsAllRecords()
             throws Exception
     {
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                new Constraints(ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), 10_000, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                constraintsWithLimit(10_000));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testReadScanSplit: rows[{}]", response.getRecordCount());
 
         assertEquals(1000, response.getRecords().getRowCount());
@@ -332,7 +293,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testReadScanSplitFiltered()
+    public void doReadRecords_withScanSplitAndFilter_filtersRecords()
             throws Exception
     {
         Map<String, String> expressionNames = ImmutableMap.of("#col_6", "col_6");
@@ -346,22 +307,15 @@ public class DynamoDBRecordHandlerTest
                 .add(EXPRESSION_VALUES_METADATA, EnhancedDocument.fromAttributeValueMap(expressionValues).toJson())
                 .build();
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testReadScanSplitFiltered: rows[{}]", response.getRecordCount());
 
         assertEquals(992, response.getRecords().getRowCount());
@@ -369,7 +323,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testReadQuerySplit()
+    public void doReadRecords_withQuerySplit_readsMatchingRecords()
             throws Exception
     {
         Map<String, String> expressionNames = ImmutableMap.of("#col_1", "col_1");
@@ -383,22 +337,15 @@ public class DynamoDBRecordHandlerTest
                 .add(EXPRESSION_VALUES_METADATA, EnhancedDocument.fromAttributeValueMap(expressionValues).toJson())
                 .build();
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testReadQuerySplit: rows[{}]", response.getRecordCount());
 
         assertEquals(2, response.getRecords().getRowCount());
@@ -406,7 +353,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testReadQuerySplitWithLimit()
+    public void doReadRecords_withQuerySplitAndLimit_readsLimitedRecords()
             throws Exception
     {
         Map<String, String> expressionNames = ImmutableMap.of("#col_1", "col_1");
@@ -420,22 +367,15 @@ public class DynamoDBRecordHandlerTest
                 .add(EXPRESSION_VALUES_METADATA, EnhancedDocument.fromAttributeValueMap(expressionValues).toJson())
                 .build();
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                new Constraints(ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), 1, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                constraintsWithLimit(1));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testReadQuerySplit: rows[{}]", response.getRecordCount());
 
         assertEquals(1, response.getRecords().getRowCount());
@@ -443,7 +383,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testZeroRowQuery()
+    public void doReadRecords_withQuerySplitNoMatches_readsZeroRecords()
             throws Exception
     {
         Map<String, String> expressionNames = ImmutableMap.of("#col_1", "col_1");
@@ -457,29 +397,22 @@ public class DynamoDBRecordHandlerTest
                 .add(EXPRESSION_VALUES_METADATA, EnhancedDocument.fromAttributeValueMap(expressionValues).toJson())
                 .build();
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testZeroRowQuery: rows[{}]", response.getRecordCount());
 
         assertEquals(0, response.getRecords().getRowCount());
     }
 
     @Test
-    public void testDateTimeSupportFromGlueTable() throws Exception
+    public void doReadRecords_withDateTimeSupportFromGlueTable_formatsDates() throws Exception
     {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
@@ -513,26 +446,16 @@ public class DynamoDBRecordHandlerTest
 
         Schema schema3 = getTableResponse.getSchema();
 
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE3)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE3);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_3_NAME,
                 schema3,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
 
         LocalDate expectedDate = LocalDate.of(2020, 02, 27);
         LocalDateTime expectedDateTime = LocalDateTime.of(2020, 2, 27, 9, 12, 27);
@@ -547,7 +470,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testStructWithNullFromGlueTable() throws Exception
+    public void doReadRecords_withStructWithNullFromGlueTable_preservesNullInStruct() throws Exception
     {
         List<Column> columns = new ArrayList<>();
         columns.add(Column.builder().name("col0").type("string").build());
@@ -584,20 +507,14 @@ public class DynamoDBRecordHandlerTest
                 .add(SEGMENT_COUNT_METADATA, "1")
                 .build();
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_4_NAME,
                 schema4,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testStructWithNullFromGlueTable: {}", BlockUtils.rowToString(response.getRecords(), 0));
         Block result = response.getRecords();
         assertEquals(1, result.getRowCount());
@@ -606,7 +523,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testStructWithNullFromDdbTable() throws Exception
+    public void doReadRecords_withStructWithNullFromDdbTable_removesNullFromStruct() throws Exception
     {
         when(glueClient.getTable(any(software.amazon.awssdk.services.glue.model.GetTableRequest.class))).thenThrow(EntityNotFoundException.builder().message("").build());
 
@@ -623,26 +540,16 @@ public class DynamoDBRecordHandlerTest
                 assertTrue(f.getType() instanceof ArrowType.Struct);
             }
         }
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE4)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE4);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_4_NAME,
                 schema4,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testStructWithNullFromGlueTable: {}", BlockUtils.rowToString(response.getRecords(), 0));
         Block result = response.getRecords();
         assertEquals(1, result.getRowCount());
@@ -651,7 +558,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testMapWithSchemaFromGlueTable() throws Exception
+    public void doReadRecords_withMapWithSchemaFromGlueTable_preservesMapStructure() throws Exception
     {
         // Disable this test if MAP_DISABLED
         if (GlueFieldLexer.MAP_DISABLED) {
@@ -682,26 +589,16 @@ public class DynamoDBRecordHandlerTest
 
         Schema schema5 = getTableResponse.getSchema();
 
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE5)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE5);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_5_NAME,
                 schema5,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testMapWithSchemaFromGlueTable: {}", BlockUtils.rowToString(response.getRecords(), 0));
         Block result = response.getRecords();
         assertEquals(1, result.getRowCount());
@@ -710,7 +607,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testStructWithSchemaFromGlueTable() throws Exception
+    public void doReadRecords_withStructWithSchemaFromGlueTable_preservesStructStructure() throws Exception
     {
         List<Column> columns = new ArrayList<>();
         columns.add(Column.builder().name("col0").type("string").build());
@@ -736,26 +633,16 @@ public class DynamoDBRecordHandlerTest
 
         Schema schema = getTableResponse.getSchema();
 
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE6)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE6);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_6_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testStructWithSchemaFromGlueTable: {}", BlockUtils.rowToString(response.getRecords(), 0));
         Block result = response.getRecords();
         assertEquals(1, result.getRowCount());
@@ -765,7 +652,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testListWithSchemaFromGlueTable() throws Exception
+    public void doReadRecords_withListWithSchemaFromGlueTable_preservesListStructure() throws Exception
     {
         List<Column> columns = new ArrayList<>();
         columns.add(Column.builder().name("col0").type("string").build());
@@ -792,26 +679,16 @@ public class DynamoDBRecordHandlerTest
 
         Schema schema = getTableResponse.getSchema();
 
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE7)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE7);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_7_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testListWithSchemaFromGlueTable: {}", BlockUtils.rowToString(response.getRecords(), 0));
         Block result = response.getRecords();
         assertEquals(1, result.getRowCount());
@@ -843,7 +720,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testNumMapWithSchemaFromGlueTable() throws Exception
+    public void doReadRecords_withNumMapWithSchemaFromGlueTable_preservesNumMapStructure() throws Exception
     {
         // Disable this test if MAP_DISABLED
         if (GlueFieldLexer.MAP_DISABLED) {
@@ -873,26 +750,16 @@ public class DynamoDBRecordHandlerTest
 
         Schema schema = getTableResponse.getSchema();
 
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE8)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE8);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_8_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testNumMapWithSchemaFromGlueTable: {}", BlockUtils.rowToString(response.getRecords(), 0));
         Block result = response.getRecords();
         assertEquals(1, result.getRowCount());
@@ -913,7 +780,7 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testNumStructWithSchemaFromGlueTable() throws Exception
+    public void doReadRecords_withNumStructWithSchemaFromGlueTable_preservesNumStructStructure() throws Exception
     {
         List<Column> columns = new ArrayList<>();
         columns.add(Column.builder().name("col0").type("string").build());
@@ -938,26 +805,16 @@ public class DynamoDBRecordHandlerTest
 
         Schema schema = getTableResponse.getSchema();
 
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, TEST_TABLE8)
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit(TEST_TABLE8);
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 TEST_TABLE_8_NAME,
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L, // too big to spill
-                100_000_000_000L);
+                defaultConstraints());
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
-        assertTrue(rawResponse instanceof ReadRecordsResponse);
-        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
         logger.info("testNumStructWithSchemaFromGlueTable: {}", BlockUtils.rowToString(response.getRecords(), 0));
         Block result = response.getRecords();
         assertEquals(1, result.getRowCount());
@@ -969,35 +826,241 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void testResourceNotFoundExceptionHandling() throws Exception
+    public void doReadRecords_withNonExistentTable_throwsAthenaConnectorException() throws Exception
     {
-        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
-                .add(TABLE_METADATA, "nonexistent_table")
-                .add(SEGMENT_ID_PROPERTY, "0")
-                .add(SEGMENT_COUNT_METADATA, "1")
-                .build();
+        Split split = createScanSplit("nonexistent_table");
 
-        ReadRecordsRequest request = new ReadRecordsRequest(
-                TEST_IDENTITY,
-                TEST_CATALOG_NAME,
-                TEST_QUERY_ID,
+        ReadRecordsRequest request = createReadRecordsRequest(
                 new TableName(DEFAULT_SCHEMA, "nonexistent_table"),
                 schema,
                 split,
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                100_000_000_000L,
-                100_000_000_000L);
+                defaultConstraints());
 
         AthenaConnectorException exception = assertThrows(AthenaConnectorException.class, () -> {
             handler.doReadRecords(allocator, request);
         });
-        Assert.assertEquals(FederationSourceErrorCode.ENTITY_NOT_FOUND_EXCEPTION.toString(),
+        assertEquals(FederationSourceErrorCode.ENTITY_NOT_FOUND_EXCEPTION.toString(),
                 exception.getErrorDetails().errorCode());
+    }
+
+    @Test
+    public void doReadRecords_withQueryPassthroughPartiQLQuery_readsRecordsMatchingQuery()
+            throws Exception
+    {
+        // Prepare the constraints with query passthrough enabled
+        Map<String, String> qptArguments = ImmutableMap.of(
+                "schemaFunctionName", SCHEMA_FUNCTION_NAME,
+                DDBQueryPassthrough.QUERY, SELECT_COL_0_COL_1_QUERY
+        );
+
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                DEFAULT_NO_LIMIT,
+                qptArguments,
+                null
+        );
+
+        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
+                .add(TABLE_METADATA, TEST_TABLE)
+                .applyProperties(qptArguments)
+                .build();
+
+        ReadRecordsRequest request = createReadRecordsRequest(
+                TEST_TABLE_NAME,
+                schema,
+                split,
+                constraints);
+
+        RecordResponse rawResponse = handler.doReadRecords(allocator, request);
+
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
+
+        logger.info("doReadRecords_withQueryPassthroughPartiQLQuery_returnsRecordsMatchingQuery: rows[{}]", response.getRecordCount());
+
+        assertTrue("Should have at least one record from query passthrough", response.getRecords().getRowCount() >= 1);
+
+        // Verify the data structure is correct - all returned records should have col_0 = 'test_str_0'
+        Block records = response.getRecords();
+        logger.info("doReadRecords_withQueryPassthroughPartiQLQuery_returnsRecordsMatchingQuery: Found {} records", records.getRowCount());
+
+        // Verify the first record to confirm query passthrough is working
+        String col0Value = records.getFieldReader(COL_0).readText().toString();
+        logger.info("doReadRecords_withQueryPassthroughPartiQLQuery_returnsRecordsMatchingQuery: First record: col_0={}, col_1={}",
+                col0Value, records.getFieldReader(COL_1).readBigDecimal());
+        assertEquals("col_0 value should match expected test string", TEST_STR_0, col0Value);
+        // col_1 should be a valid number
+        assertNotNull("col_1 should not be null", records.getFieldReader(COL_1).readBigDecimal());
+    }
+
+    @Test
+    public void doReadRecords_withInFilterOnRangeKey_queriesWithMultipleValues()
+            throws Exception
+    {
+        Map<String, AttributeValue> expressionValues = ImmutableMap.of(
+                ":v1", DDBTypeUtils.toAttributeValue(VALUE_1),
+                ":v2", DDBTypeUtils.toAttributeValue(VALUE_2),
+                ":v3", DDBTypeUtils.toAttributeValue(VALUE_3));
+        Split split = createQuerySplitWithRangeFilter("#col_1 IN (:v1,:v2,:v3)", expressionValues);
+
+        ReadRecordsRequest request = createReadRecordsRequest(
+                TEST_TABLE_NAME,
+                schema,
+                split,
+                defaultConstraints());
+
+        RecordResponse rawResponse = handler.doReadRecords(allocator, request);
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
+        assertNotNull("Response should not be null", response);
+    }
+
+    @Test
+    public void doReadRecords_withEqualityFilterOnRangeKey_queriesWithSingleValue()
+            throws Exception
+    {
+        Map<String, AttributeValue> expressionValues = ImmutableMap.of(":v0", DDBTypeUtils.toAttributeValue(VALUE_1));
+        Split split = createQuerySplitWithRangeFilter("#col_1 = :v0", expressionValues);
+
+        ReadRecordsRequest request = createReadRecordsRequest(
+                TEST_TABLE_NAME,
+                schema,
+                split,
+                defaultConstraints());
+
+        RecordResponse rawResponse = handler.doReadRecords(allocator, request);
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
+        assertNotNull("Response should not be null", response);
+    }
+
+    @Test
+    public void doReadRecords_withQuerySplitWithoutRangeKeyFilter_handlesQueryWithHashKeyOnly()
+            throws Exception
+    {
+        Split split = createQuerySplitWithoutRangeFilter();
+
+        ReadRecordsRequest request = createReadRecordsRequest(
+                TEST_TABLE_NAME,
+                schema,
+                split,
+                defaultConstraints());
+
+        RecordResponse rawResponse = handler.doReadRecords(allocator, request);
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
+        assertNotNull("Response should not be null", response);
+    }
+
+    @Test
+    public void doReadRecords_withInvalidSplitMetadata_throwsIllegalArgumentOrAthenaConnectorException()
+    {
+        try {
+            Split invalidSplit = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
+                    .add(TABLE_METADATA, "invalid_table")
+                    .add(SEGMENT_ID_PROPERTY, "invalid")
+                    .add(SEGMENT_COUNT_METADATA, "1")
+                    .build();
+
+            ReadRecordsRequest request = createReadRecordsRequest(
+                    new TableName(DEFAULT_SCHEMA, "invalid_table"),
+                    schema,
+                    invalidSplit,
+                    defaultConstraints());
+
+            handler.doReadRecords(allocator, request);
+            fail("Expected exception was not thrown for invalid split metadata");
+        }
+        catch (Exception ex) {
+            assertTrue("Exception should be IllegalArgumentException or AthenaConnectorException for invalid split metadata",
+                    ex instanceof IllegalArgumentException || ex instanceof AthenaConnectorException);
+        }
+    }
+
+    @Test
+    public void doReadRecords_withEmptyTable_readsZeroRecords()
+            throws Exception
+    {
+        Split split = createScanSplit(TEST_TABLE2);
+
+        ReadRecordsRequest request = createReadRecordsRequest(
+                TEST_TABLE_2_NAME,
+                schema,
+                split,
+                defaultConstraints());
+
+        RecordResponse rawResponse = handler.doReadRecords(allocator, request);
+        ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
+
+        assertEquals("Empty table should return zero records", 0, response.getRecords().getRowCount());
     }
 
     private long getPackedDateTimeWithZone(String s)
     {
         ZonedDateTime zdt = ZonedDateTime.parse(s);
         return DateTimeFormatterUtil.timestampMilliTzHolderFromObject(zdt, null).value;
+    }
+    private Split createQuerySplitWithRangeFilter(String rangeFilter, Map<String, AttributeValue> expressionValues)
+    {
+        Map<String, String> expressionNames = ImmutableMap.of("#col_1", COL_1);
+        return Split.newBuilder(SPILL_LOCATION, keyFactory.create())
+                .add(TABLE_METADATA, TEST_TABLE)
+                .add(HASH_KEY_NAME_METADATA, COL_0)
+                .add(COL_0, DDBTypeUtils.attributeToJson(DDBTypeUtils.toAttributeValue(TEST_STR_0), COL_0))
+                .add(RANGE_KEY_FILTER_METADATA, rangeFilter)
+                .add(EXPRESSION_NAMES_METADATA, toJsonString(expressionNames))
+                .add(EXPRESSION_VALUES_METADATA, EnhancedDocument.fromAttributeValueMap(expressionValues).toJson())
+                .build();
+    }
+
+    private Split createQuerySplitWithoutRangeFilter()
+    {
+        return Split.newBuilder(SPILL_LOCATION, keyFactory.create())
+                .add(TABLE_METADATA, TEST_TABLE)
+                .add(HASH_KEY_NAME_METADATA, COL_0)
+                .add(COL_0, DDBTypeUtils.attributeToJson(DDBTypeUtils.toAttributeValue(TEST_STR_0), COL_0))
+                .build();
+    }
+
+    private ReadRecordsRequest createReadRecordsRequest(TableName tableName, Schema schema, Split split, Constraints constraints)
+    {
+        return new ReadRecordsRequest(
+                TEST_IDENTITY,
+                TEST_CATALOG_NAME,
+                TEST_QUERY_ID,
+                tableName,
+                schema,
+                split,
+                constraints,
+                SPILL_SIZE,
+                SPILL_SIZE);
+    }
+
+    private Split createScanSplit(String tableName)
+    {
+        return Split.newBuilder(SPILL_LOCATION, keyFactory.create())
+                .add(TABLE_METADATA, tableName)
+                .add(SEGMENT_ID_PROPERTY, "0")
+                .add(SEGMENT_COUNT_METADATA, "1")
+                .build();
+    }
+
+    private ReadRecordsResponse assertAndCastToReadRecordsResponse(RecordResponse rawResponse)
+    {
+        assertTrue("Response should be ReadRecordsResponse", rawResponse instanceof ReadRecordsResponse);
+        return (ReadRecordsResponse) rawResponse;
+    }
+
+    private static Constraints defaultConstraints()
+    {
+        return new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+    }
+
+    private static Constraints constraintsWithLimit(long limit)
+    {
+        return new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), limit, Collections.emptyMap(), null);
+    }
+
+    private static Constraints constraintsWithQueryPlan(QueryPlan queryPlan)
+    {
+        return new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), queryPlan);
     }
 }

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
@@ -170,7 +170,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
@@ -202,7 +202,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                constraintsWithQueryPlan(queryPlan),
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), queryPlan),
                 100_000_000_000L, // too big to spill
                 100_000_000_000L);
 
@@ -237,7 +237,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                constraintsWithQueryPlan(queryPlan),
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), queryPlan),
                 100_000_000_000L, // too big to spill
                 100_000_000_000L);
 
@@ -260,7 +260,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                constraintsWithLimit(5));
+                getConstraints(5, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
@@ -281,7 +281,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                constraintsWithLimit(10_000));
+                getConstraints(10_000, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
@@ -311,7 +311,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
@@ -341,7 +341,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
@@ -371,7 +371,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                constraintsWithLimit(1));
+                getConstraints(1, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
@@ -401,7 +401,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
@@ -452,7 +452,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_3_NAME,
                 schema3,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -511,7 +511,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_4_NAME,
                 schema4,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -546,7 +546,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_4_NAME,
                 schema4,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -595,7 +595,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_5_NAME,
                 schema5,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -639,7 +639,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_6_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -685,7 +685,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_7_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -756,7 +756,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_8_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -811,7 +811,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_8_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -826,15 +826,14 @@ public class DynamoDBRecordHandlerTest
     }
 
     @Test
-    public void doReadRecords_withNonExistentTable_throwsAthenaConnectorException() throws Exception
-    {
+    public void doReadRecords_withNonExistentTable_throwsAthenaConnectorException() {
         Split split = createScanSplit("nonexistent_table");
 
         ReadRecordsRequest request = createReadRecordsRequest(
                 new TableName(DEFAULT_SCHEMA, "nonexistent_table"),
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         AthenaConnectorException exception = assertThrows(AthenaConnectorException.class, () -> {
             handler.doReadRecords(allocator, request);
@@ -853,14 +852,7 @@ public class DynamoDBRecordHandlerTest
                 DDBQueryPassthrough.QUERY, SELECT_COL_0_COL_1_QUERY
         );
 
-        Constraints constraints = new Constraints(
-                Collections.emptyMap(),
-                Collections.emptyList(),
-                Collections.emptyList(),
-                DEFAULT_NO_LIMIT,
-                qptArguments,
-                null
-        );
+        Constraints readConstraints = getConstraints(DEFAULT_NO_LIMIT, qptArguments, null);
 
         Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
                 .add(TABLE_METADATA, TEST_TABLE)
@@ -871,7 +863,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                constraints);
+                readConstraints);
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
 
@@ -908,7 +900,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -926,7 +918,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -943,7 +935,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -964,7 +956,7 @@ public class DynamoDBRecordHandlerTest
                     new TableName(DEFAULT_SCHEMA, "invalid_table"),
                     schema,
                     invalidSplit,
-                    defaultConstraints());
+                    getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
             handler.doReadRecords(allocator, request);
             fail("Expected exception was not thrown for invalid split metadata");
@@ -985,7 +977,7 @@ public class DynamoDBRecordHandlerTest
                 TEST_TABLE_2_NAME,
                 schema,
                 split,
-                defaultConstraints());
+                getConstraints(DEFAULT_NO_LIMIT, Collections.emptyMap(), null));
 
         RecordResponse rawResponse = handler.doReadRecords(allocator, request);
         ReadRecordsResponse response = assertAndCastToReadRecordsResponse(rawResponse);
@@ -1049,18 +1041,17 @@ public class DynamoDBRecordHandlerTest
         return (ReadRecordsResponse) rawResponse;
     }
 
-    private static Constraints defaultConstraints()
+    private static Constraints getConstraints(
+            long limit,
+            Map<String, String> queryPassthroughArguments,
+            QueryPlan queryPlan)
     {
-        return new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
-    }
-
-    private static Constraints constraintsWithLimit(long limit)
-    {
-        return new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), limit, Collections.emptyMap(), null);
-    }
-
-    private static Constraints constraintsWithQueryPlan(QueryPlan queryPlan)
-    {
-        return new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), queryPlan);
+        return new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                limit,
+                queryPassthroughArguments,
+                queryPlan);
     }
 }

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
@@ -104,6 +104,7 @@ public class TestBase
     protected static final TableName TEST_TABLE_6_NAME = new TableName(DEFAULT_SCHEMA, TEST_TABLE6);
     protected static final TableName TEST_TABLE_7_NAME = new TableName(DEFAULT_SCHEMA, TEST_TABLE7);
     protected static final TableName TEST_TABLE_8_NAME = new TableName(DEFAULT_SCHEMA, TEST_TABLE8);
+    protected static final String TEST_FIELD = "col1";
 
     protected static DynamoDbClient ddbClient;
     protected static Schema schema;

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/credentials/CrossAccountCredentialsProviderV2Test.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/credentials/CrossAccountCredentialsProviderV2Test.java
@@ -74,7 +74,7 @@ public class CrossAccountCredentialsProviderV2Test
         }
         catch (AthenaConnectorException ex) {
             assertTrue("Exception message should contain error about failed to assume role",
-                    ex.getMessage() != null && ex.getMessage().contains("Failed to assume role"));
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Failed to assume role"));
         }
     }
 
@@ -90,7 +90,7 @@ public class CrossAccountCredentialsProviderV2Test
         }
         catch (AthenaConnectorException ex) {
             assertTrue("Exception message should reference failed to assume role",
-                    ex.getMessage() != null && ex.getMessage().contains("Failed to assume role"));
+                    ex.getMessage() != null && !ex.getMessage().isEmpty() && ex.getMessage().contains("Failed to assume role"));
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and renamed tests across the suite for clearer, descriptive names.
  * Added IN/NOT IN (whitelist/blacklist) predicate tests, sanitization, and extensive null/edge-case coverage.
  * Broad coverage added for Arrow field inference, type coercion, DDB-to-Arrow mappings, extractor behavior, and JSON/attribute conversion error paths.
  * New metadata and record handler tests for query-passthrough (schema, splits, capabilities) and range/key filtering.
  * Credential tests extended with extra edge-case checks and a new shared test constant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Risk is mainly from dependency bumps (AWS SDK v2, Zookeeper, CloudWatchLogs) and changing Redshift SQL generation to use `RedshiftSqlDialect`, which could affect query pushdown/quoting behavior. Most other changes are test-only refactors/additions with low runtime impact.
> 
> **Overview**
> **Updates dependencies** across modules (e.g., Zookeeper `3.9.4`→`3.9.5`, AWS SDK v2 `2.42.4`→`2.42.14`, CloudWatchLogs `2.41.21`→`2.42.16`, and testing Python deps like `PyJWT`).
> 
> **Redshift connector** now uses a new `RedshiftSqlQueryStringBuilder` that overrides the Calcite dialect to `RedshiftSqlDialect` (replacing the PostgreSQL builder), with new/updated unit tests validating construction and dialect selection.
> 
> **DynamoDB connector tests** are heavily expanded/renamed for clarity and edge-case coverage, including new cases for `IN`/`NOT IN` predicate generation from `ValueSet`, Arrow field inference/type coercion and conversion error paths, query passthrough schema/splits/capabilities behavior, and additional negative tests for invalid metadata and credential configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcc2167a2128d11b9ce2ba9b5343b38282f94a3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->